### PR TITLE
Cister.ValueLinq benchmarks for ToArray/ToList

### DIFF
--- a/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToArray.CisternValueLinq.cs
@@ -1,0 +1,74 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using StructLinq;
+using System.Buffers;
+
+namespace LinqBenchmarks.Array.Int32
+{
+    public partial class ArrayInt32WhereSelectToArray: ArrayInt32BenchmarkBase
+    {
+        [Benchmark]
+        public int[] ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToArray.cs
+++ b/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToArray.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Array.Int32
 {
-    public class ArrayInt32WhereSelectToArray: ArrayInt32BenchmarkBase
+    public partial class ArrayInt32WhereSelectToArray: ArrayInt32BenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public int[] ForLoop()

--- a/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToList.CisternValueLinq.cs
@@ -1,0 +1,73 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.Array.Int32
+{
+    public partial class ArrayInt32WhereSelectToList
+    {
+        [Benchmark]
+        public List<int> ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToList.cs
+++ b/LinqBenchmarks/Array/Int32/ArrayInt32WhereSelectToList.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Array.Int32
 {
-    public class ArrayInt32WhereSelectToList: ArrayInt32BenchmarkBase
+    public partial class ArrayInt32WhereSelectToList: ArrayInt32BenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<int> ForLoop()

--- a/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToArray.CisternValueLinq.cs
@@ -1,0 +1,132 @@
+﻿#if !NETFRAMEWORK
+
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+namespace LinqBenchmarks.Array.ValueType
+{
+    public partial class ArrayValueTypeWhereSelectToArray: ValueTypeArrayBenchmarkBase
+    {
+        [Benchmark]
+        public FatValueType[] ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_Standard() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_Stack() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_SharedPool_Push() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_SharedPool_Pull() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<FatValueType, bool> { public bool Invoke(FatValueType t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<FatValueType, FatValueType> { public FatValueType Invoke(FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: false);
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: true);
+
+        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
+        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_Standard() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_Stack() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: true);
+
+    }
+}
+
+#endif

--- a/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToArray.cs
+++ b/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToArray.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Array.ValueType
 {
-    public class ArrayValueTypeWhereSelectToArray: ValueTypeArrayBenchmarkBase
+    public partial class ArrayValueTypeWhereSelectToArray: ValueTypeArrayBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public FatValueType[] ForLoop()

--- a/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToList.CisternValueLinq.cs
@@ -1,0 +1,132 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.Array.ValueType
+{
+    public partial class ArrayValueTypeWhereSelectToList
+    {
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull:false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull:true);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_Standard() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_Stack() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_SharedPool_Push() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_SharedPool_Pull() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<FatValueType, bool> { public bool Invoke(FatValueType t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<FatValueType, FatValueType> { public FatValueType Invoke(FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: false);
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: true);
+
+        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
+        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_Standard() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_Stack() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: true);
+
+    }
+}
+
+#endif

--- a/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToList.cs
+++ b/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToList.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Array.ValueType
 { 
-    public class ArrayValueTypeWhereSelectToList: ValueTypeArrayBenchmarkBase
+    public partial class ArrayValueTypeWhereSelectToList: ValueTypeArrayBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<FatValueType> ForLoop()

--- a/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToArray.CisternValueLinq.cs
@@ -1,0 +1,72 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+namespace LinqBenchmarks.Enumerable.Int32
+{
+    public partial class EnumerableInt32WhereSelectToArray : EnumerableInt32BenchmarkBase
+    {
+        [Benchmark]
+        public int[] ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToArray.cs
+++ b/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToArray.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Enumerable.Int32
 {
-    public class EnumerableInt32WhereSelectToArray: EnumerableInt32BenchmarkBase
+    public partial class EnumerableInt32WhereSelectToArray: EnumerableInt32BenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public int[] ForeachLoop()

--- a/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToList.CisternValueLinq.cs
@@ -1,0 +1,73 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.Enumerable.Int32
+{
+    public partial class EnumerableInt32WhereSelectToList: EnumerableInt32BenchmarkBase
+    {
+        [Benchmark]
+        public List<int> ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToList.cs
+++ b/LinqBenchmarks/Enumerable/Int32/EnumerableInt32WhereSelectToList.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Enumerable.Int32
 {
-    public class EnumerableInt32WhereSelectToList: EnumerableInt32BenchmarkBase
+    public partial class EnumerableInt32WhereSelectToList: EnumerableInt32BenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<int> ForeachLoop()

--- a/LinqBenchmarks/LinqBenchmarks.csproj
+++ b/LinqBenchmarks/LinqBenchmarks.csproj
@@ -21,4 +21,16 @@
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Cistern.ValueLinq">
+      <Version>0.0.10</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Cistern.ValueLinq">
+      <Version>0.0.10</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/LinqBenchmarks/List/Int32/ListInt32WhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/List/Int32/ListInt32WhereSelectToArray.CisternValueLinq.cs
@@ -1,0 +1,143 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+
+namespace LinqBenchmarks.List.Int32
+{
+    public partial class ListInt32WhereSelectToArray: Int32ListBenchmarkBase
+    {
+        [Benchmark]
+        public int[] ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: true);
+
+
+
+
+
+
+        [Benchmark]
+        public int[] ValueLinq_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/List/Int32/ListInt32WhereSelectToArray.cs
+++ b/LinqBenchmarks/List/Int32/ListInt32WhereSelectToArray.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.List.Int32
 {
-    public class ListInt32WhereSelectToArray: Int32ListBenchmarkBase
+    public partial class ListInt32WhereSelectToArray: Int32ListBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public int[] ForLoop()

--- a/LinqBenchmarks/List/Int32/ListInt32WhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/List/Int32/ListInt32WhereSelectToList.CisternValueLinq.cs
@@ -1,0 +1,139 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.List.Int32
+{
+    public partial class ListInt32WhereSelectToList: Int32ListBenchmarkBase
+    {
+        [Benchmark]
+        public List<int> ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: true);
+
+
+
+        [Benchmark]
+        public List<int> ValueLinq_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/List/Int32/ListInt32WhereSelectToList.cs
+++ b/LinqBenchmarks/List/Int32/ListInt32WhereSelectToList.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.List.Int32
 {
-    public class ListInt32WhereSelectToList: Int32ListBenchmarkBase
+    public partial class ListInt32WhereSelectToList : Int32ListBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<int> ForLoop()

--- a/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToArray.CisternValueLinq.cs
@@ -1,0 +1,262 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+namespace LinqBenchmarks.List.ValueType
+{
+    public partial class ListValueTypeWhereSelectToArray: ValueTypeListBenchmarkBase
+    {
+        [Benchmark]
+        public FatValueType[] ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_Standard() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_Stack() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_SharedPool_Push() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_SharedPool_Pull() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<FatValueType, bool> { public bool Invoke(FatValueType t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<FatValueType, FatValueType> { public FatValueType Invoke(FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: false);
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: true);
+
+        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
+        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_Standard() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_Stack() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: true);
+
+
+
+
+
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_Ref_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: false);
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: true);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArray();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToArrayUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToArray.cs
+++ b/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToArray.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.List.ValueType
 {
-    public class ListValueTypeWhereSelectToArray: ValueTypeListBenchmarkBase
+    public partial class ListValueTypeWhereSelectToArray: ValueTypeListBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public FatValueType[] ForLoop()

--- a/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToList.CisternValueLinq.cs
@@ -1,0 +1,263 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.List.ValueType
+{
+    public partial class ListValueTypeWhereSelectToList: ValueTypeListBenchmarkBase
+    {
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Standard() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Stack() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_SharedPool_Push() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_SharedPool_Pull() =>
+            source
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_Standard() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_Stack() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_SharedPool_Push() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_SharedPool_Pull() =>
+            source
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUsePool(viaPull: true);
+
+
+        struct IsEven : IFunc<FatValueType, bool> { public bool Invoke(FatValueType t) => t.IsEven(); }
+        struct MultipleByTwo : IFunc<FatValueType, FatValueType> { public FatValueType Invoke(FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Standard() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Stack() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_SharedPool_Push() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: false);
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_SharedPool_Pull() =>
+            source
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: true);
+
+        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
+        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_Standard() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_Stack() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
+            source
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: true);
+
+
+
+
+
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(item => item.IsEven())
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_Ref_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where((in FatValueType item) => item.IsEven())
+            .Select((in FatValueType item) => item * 2)
+            .ToListUsePool(viaPull: true);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: false);
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new IsEven())
+            .Select(new MultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: true);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_Standard_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToList();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_Stack_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Push_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Pull_ByIndex() =>
+            source
+            .OfListByIndex()
+            .Where(new InIsEven())
+            .Select(new InMultipleByTwo(), default(FatValueType))
+            .ToListUsePool(viaPull: true);
+    }
+}
+
+#endif

--- a/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToList.cs
+++ b/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToList.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.List.ValueType
 {
-    public class ListValueTypeWhereSelectToList: ValueTypeListBenchmarkBase
+    public partial class ListValueTypeWhereSelectToList: ValueTypeListBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<FatValueType> ForLoop()

--- a/LinqBenchmarks/Range/RangeSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/Range/RangeSelectToArray.CisternValueLinq.cs
@@ -1,0 +1,72 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using StructLinq;
+using System.Buffers;
+
+namespace LinqBenchmarks.Range
+{
+    public partial class RangeSelectToArray: RangeBenchmarkBase
+    {
+        [Benchmark]
+        public int[] ValueLinq_Standard() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_Stack() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Push() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Pull() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToArrayUsePool(viaPull: true);
+
+
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Standard() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_Stack() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Push() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_ValueLambda_SharedPool_Pull() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToArrayUsePool(viaPull: true);
+    }
+}
+#endif

--- a/LinqBenchmarks/Range/RangeSelectToArray.cs
+++ b/LinqBenchmarks/Range/RangeSelectToArray.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Range
 {
-    public class RangeSelectToArray: RangeBenchmarkBase
+    public partial class RangeSelectToArray : RangeBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public int[] ForLoop()

--- a/LinqBenchmarks/Range/RangeSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/Range/RangeSelectToList.CisternValueLinq.cs
@@ -1,0 +1,72 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using StructLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.Range
+{
+    public partial class RangeSelectToList: RangeBenchmarkBase
+    {
+        [Benchmark]
+        public List<int> ValueLinq_Standard() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_Stack() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Push() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Pull() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(item => item * 2)
+            .ToListUsePool(viaPull: true);
+
+
+        struct MultipleByTwo : IFunc<int, int> { public int Invoke(int t) => t * 2; }
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Standard() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_Stack() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Push() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_ValueLambda_SharedPool_Pull() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .Select(new MultipleByTwo(), default(int))
+            .ToListUsePool(viaPull: true);
+    }
+}
+#endif

--- a/LinqBenchmarks/Range/RangeSelectToList.cs
+++ b/LinqBenchmarks/Range/RangeSelectToList.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Range
 {
-    public class RangeSelectToList: RangeBenchmarkBase
+    public partial class RangeSelectToList: RangeBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<int> ForLoop()

--- a/LinqBenchmarks/Range/RangeToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/Range/RangeToArray.CisternValueLinq.cs
@@ -1,0 +1,37 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using StructLinq;
+using System.Buffers;
+
+namespace LinqBenchmarks.Range
+{
+    public partial class RangeToArray: RangeBenchmarkBase
+    {
+        [Benchmark]
+        public int[] ValueLinq_Standard() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToArray();
+
+        [Benchmark]
+        public int[] ValueLinq_Stack() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToArrayUseStack();
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Push() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToArrayUsePool(viaPull: false);
+
+        [Benchmark]
+        public int[] ValueLinq_SharedPool_Pull() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToArrayUsePool(viaPull: true);
+    }
+}
+#endif

--- a/LinqBenchmarks/Range/RangeToArray.cs
+++ b/LinqBenchmarks/Range/RangeToArray.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Range
 {
-    public class RangeToArray: RangeBenchmarkBase
+    public partial class RangeToArray: RangeBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public int[] ForLoop()

--- a/LinqBenchmarks/Range/RangeToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/Range/RangeToList.CisternValueLinq.cs
@@ -1,0 +1,37 @@
+﻿#if !NETFRAMEWORK
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using StructLinq;
+using System.Collections.Generic;
+
+namespace LinqBenchmarks.Range
+{
+    public partial class RangeToList : RangeBenchmarkBase
+    {
+        [Benchmark]
+        public List<int> ValueLinq_Standard() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToList();
+
+        [Benchmark]
+        public List<int> ValueLinq_Stack() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToListUseStack();
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Push() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToListUsePool(viaPull: false);
+
+        [Benchmark]
+        public List<int> ValueLinq_SharedPool_Pull() =>
+            Cistern.ValueLinq.Enumerable
+            .Range(Start, Count)
+            .ToListUsePool(viaPull: true);
+    }
+}
+#endif

--- a/LinqBenchmarks/Range/RangeToList.cs
+++ b/LinqBenchmarks/Range/RangeToList.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace LinqBenchmarks.Range
 {
-    public class RangeToList: RangeBenchmarkBase
+    public partial class RangeToList: RangeBenchmarkBase
     {
         [Benchmark(Baseline = true)]
         public List<int> ForLoop()

--- a/Results/Array.Int32.ArrayInt32WhereSelectToArray.md
+++ b/Results/Array.Int32.ArrayInt32WhereSelectToArray.md
@@ -12,23 +12,31 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |---------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 | 239.0 ns | 3.42 ns | 3.20 ns |  1.00 |    0.00 | 0.4168 |     - |     - |     872 B |
-|          ForeachLoop |   100 | 237.8 ns | 2.33 ns | 2.18 ns |  1.00 |    0.02 | 0.4168 |     - |     - |     872 B |
-|                 Linq |   100 | 597.9 ns | 4.08 ns | 3.82 ns |  2.50 |    0.03 | 0.3710 |     - |     - |     776 B |
-|           LinqFaster |   100 | 333.1 ns | 1.38 ns | 1.29 ns |  1.39 |    0.02 | 0.3095 |     - |     - |     648 B |
-|               LinqAF |   100 | 829.1 ns | 6.13 ns | 5.73 ns |  3.47 |    0.05 | 0.4015 |     - |     - |     840 B |
-|           StructLinq |   100 | 642.9 ns | 5.31 ns | 4.43 ns |  2.69 |    0.04 | 0.1526 |     - |     - |     320 B |
-| StructLinq_IFunction |   100 | 363.8 ns | 2.93 ns | 2.60 ns |  1.52 |    0.02 | 0.1068 |     - |     - |     224 B |
-|            Hyperlinq |   100 | 588.2 ns | 2.82 ns | 2.64 ns |  2.46 |    0.04 | 0.1068 |     - |     - |     224 B |
-|       Hyperlinq_Pool |   100 | 663.7 ns | 5.17 ns | 4.58 ns |  2.78 |    0.03 | 0.0267 |     - |     - |      56 B |
+|                                Method | Count |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------- |------ |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
+|                    ValueLinq_Standard |   100 | 1,203.1 ns |  10.34 ns |   9.17 ns | 1,202.0 ns |  1.93 |    0.12 | 0.1774 |     - |     - |     744 B |
+|                       ValueLinq_Stack |   100 |   922.3 ns |  18.17 ns |  22.32 ns |   924.2 ns |  1.46 |    0.09 | 0.0534 |     - |     - |     224 B |
+|             ValueLinq_SharedPool_Push |   100 | 1,286.1 ns |  25.22 ns |  39.27 ns | 1,293.1 ns |  2.04 |    0.14 | 0.0534 |     - |     - |     224 B |
+|             ValueLinq_SharedPool_Pull |   100 | 1,283.0 ns |  25.42 ns |  46.49 ns | 1,286.2 ns |  2.03 |    0.12 | 0.0534 |     - |     - |     224 B |
+|        ValueLinq_ValueLambda_Standard |   100 |   941.3 ns |  18.68 ns |  44.39 ns |   956.0 ns |  1.48 |    0.11 | 0.1774 |     - |     - |     744 B |
+|           ValueLinq_ValueLambda_Stack |   100 |   598.1 ns |  12.09 ns |  31.86 ns |   600.6 ns |  0.94 |    0.06 | 0.0534 |     - |     - |     224 B |
+| ValueLinq_ValueLambda_SharedPool_Push |   100 | 1,042.0 ns |  21.23 ns |  62.26 ns | 1,042.4 ns |  1.64 |    0.13 | 0.0534 |     - |     - |     224 B |
+| ValueLinq_ValueLambda_SharedPool_Pull |   100 | 1,092.1 ns |  21.85 ns |  57.18 ns | 1,100.6 ns |  1.72 |    0.11 | 0.0534 |     - |     - |     224 B |
+|                               ForLoop |   100 |   637.4 ns |  12.69 ns |  32.06 ns |   643.9 ns |  1.00 |    0.00 | 0.2079 |     - |     - |     872 B |
+|                           ForeachLoop |   100 |   646.5 ns |  13.00 ns |  22.08 ns |   646.2 ns |  1.02 |    0.06 | 0.2079 |     - |     - |     872 B |
+|                                  Linq |   100 | 1,256.0 ns |  25.23 ns |  69.91 ns | 1,264.8 ns |  1.97 |    0.15 | 0.1850 |     - |     - |     776 B |
+|                            LinqFaster |   100 | 3,843.5 ns | 148.99 ns | 402.80 ns | 3,700.0 ns |  6.04 |    0.73 |      - |     - |     - |     648 B |
+|                                LinqAF |   100 | 6,896.2 ns | 167.89 ns | 439.34 ns | 6,900.0 ns | 10.82 |    0.93 |      - |     - |     - |     840 B |
+|                            StructLinq |   100 | 1,277.5 ns |  25.23 ns |  54.84 ns | 1,284.9 ns |  2.01 |    0.15 | 0.0763 |     - |     - |     320 B |
+|                  StructLinq_IFunction |   100 |   927.4 ns |  18.71 ns |  53.67 ns |   937.0 ns |  1.46 |    0.12 | 0.0534 |     - |     - |     224 B |
+|                             Hyperlinq |   100 | 1,246.8 ns |  24.71 ns |  53.20 ns | 1,242.4 ns |  1.97 |    0.15 | 0.0534 |     - |     - |     224 B |
+|                        Hyperlinq_Pool |   100 | 1,308.7 ns |  26.16 ns |  55.17 ns | 1,312.4 ns |  2.07 |    0.14 | 0.0134 |     - |     - |      56 B |

--- a/Results/Array.Int32.ArrayInt32WhereSelectToList.md
+++ b/Results/Array.Int32.ArrayInt32WhereSelectToList.md
@@ -12,22 +12,30 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |---------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 | 252.2 ns | 2.56 ns | 2.39 ns |  1.00 |    0.00 | 0.3095 |     - |     - |     648 B |
-|          ForeachLoop |   100 | 248.9 ns | 1.67 ns | 1.39 ns |  0.99 |    0.01 | 0.3095 |     - |     - |     648 B |
-|                 Linq |   100 | 512.0 ns | 4.64 ns | 4.34 ns |  2.03 |    0.03 | 0.3595 |     - |     - |     752 B |
-|           LinqFaster |   100 | 406.6 ns | 1.38 ns | 1.15 ns |  1.61 |    0.02 | 0.4320 |     - |     - |     904 B |
-|               LinqAF |   100 | 833.5 ns | 5.25 ns | 4.91 ns |  3.31 |    0.03 | 0.3090 |     - |     - |     648 B |
-|           StructLinq |   100 | 678.2 ns | 5.01 ns | 4.68 ns |  2.69 |    0.03 | 0.1678 |     - |     - |     352 B |
-| StructLinq_IFunction |   100 | 397.6 ns | 2.59 ns | 2.29 ns |  1.58 |    0.02 | 0.1221 |     - |     - |     256 B |
-|            Hyperlinq |   100 | 701.1 ns | 5.35 ns | 4.47 ns |  2.78 |    0.03 | 0.1564 |     - |     - |     328 B |
+|                                Method | Count |        Mean |       Error |      StdDev |      Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------- |------ |------------:|------------:|------------:|------------:|------:|--------:|-------:|------:|------:|----------:|
+|                    ValueLinq_Standard |   100 |    969.6 ns |     5.67 ns |     5.31 ns |    967.4 ns |  1.73 |    0.17 | 0.1545 |     - |     - |     648 B |
+|                       ValueLinq_Stack |   100 |  1,203.0 ns |    14.73 ns |    13.78 ns |  1,204.6 ns |  2.14 |    0.22 | 0.0610 |     - |     - |     256 B |
+|             ValueLinq_SharedPool_Push |   100 |  1,441.3 ns |    23.31 ns |    21.80 ns |  1,438.5 ns |  2.57 |    0.27 | 0.0610 |     - |     - |     256 B |
+|             ValueLinq_SharedPool_Pull |   100 |  1,483.2 ns |    27.83 ns |    29.78 ns |  1,479.5 ns |  2.64 |    0.21 | 0.0610 |     - |     - |     256 B |
+|        ValueLinq_ValueLambda_Standard |   100 |    717.8 ns |    13.92 ns |    15.47 ns |    712.1 ns |  1.28 |    0.12 | 0.1545 |     - |     - |     648 B |
+|           ValueLinq_ValueLambda_Stack |   100 |    745.9 ns |    15.01 ns |    20.55 ns |    753.7 ns |  1.32 |    0.12 | 0.0610 |     - |     - |     256 B |
+| ValueLinq_ValueLambda_SharedPool_Push |   100 |  1,100.5 ns |    22.01 ns |    36.78 ns |  1,108.0 ns |  1.94 |    0.16 | 0.0610 |     - |     - |     256 B |
+| ValueLinq_ValueLambda_SharedPool_Pull |   100 |  1,068.3 ns |    21.35 ns |    48.63 ns |  1,086.8 ns |  1.87 |    0.15 | 0.0610 |     - |     - |     256 B |
+|                               ForLoop |   100 |    581.3 ns |    11.37 ns |    32.99 ns |    581.0 ns |  1.00 |    0.00 | 0.1545 |     - |     - |     648 B |
+|                           ForeachLoop |   100 |    607.2 ns |    12.23 ns |    24.14 ns |    611.0 ns |  1.07 |    0.08 | 0.1545 |     - |     - |     648 B |
+|                                  Linq |   100 |  1,552.9 ns |    30.94 ns |    49.97 ns |  1,555.4 ns |  2.74 |    0.23 | 0.1793 |     - |     - |     752 B |
+|                            LinqFaster |   100 |  1,340.7 ns |    26.32 ns |    43.98 ns |  1,355.3 ns |  2.37 |    0.20 | 0.2155 |     - |     - |     904 B |
+|                                LinqAF |   100 | 11,333.0 ns | 1,411.85 ns | 4,096.03 ns | 10,000.0 ns | 19.62 |    7.46 |      - |     - |     - |     648 B |
+|                            StructLinq |   100 |  1,706.4 ns |    33.84 ns |    58.37 ns |  1,706.6 ns |  3.02 |    0.26 | 0.0839 |     - |     - |     352 B |
+|                  StructLinq_IFunction |   100 |  1,010.3 ns |    20.35 ns |    34.00 ns |  1,019.7 ns |  1.78 |    0.14 | 0.0610 |     - |     - |     256 B |
+|                             Hyperlinq |   100 |  1,524.6 ns |    30.00 ns |    67.10 ns |  1,533.1 ns |  2.66 |    0.20 | 0.0782 |     - |     - |     328 B |

--- a/Results/Array.ValueType.ArrayValueTypeWhereSelectToArray.md
+++ b/Results/Array.ValueType.ArrayValueTypeWhereSelectToArray.md
@@ -12,23 +12,39 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 |   968.9 ns | 11.30 ns | 10.02 ns |  1.00 |    0.00 | 3.4103 |     - |     - |    7136 B |
-|          ForeachLoop |   100 | 1,037.5 ns |  8.62 ns |  8.06 ns |  1.07 |    0.01 | 3.4103 |     - |     - |    7136 B |
-|                 Linq |   100 | 1,312.8 ns | 14.61 ns | 13.67 ns |  1.35 |    0.02 | 2.4319 |     - |     - |    5088 B |
-|           LinqFaster |   100 | 1,031.6 ns | 10.64 ns |  8.30 ns |  1.06 |    0.01 | 2.8896 |     - |     - |    6048 B |
-|               LinqAF |   100 | 1,972.7 ns | 20.29 ns | 18.98 ns |  2.04 |    0.03 | 3.3951 |     - |     - |    7104 B |
-|           StructLinq |   100 | 1,253.0 ns |  7.23 ns |  6.41 ns |  1.29 |    0.02 | 1.0128 |     - |     - |    2120 B |
-| StructLinq_IFunction |   100 |   863.4 ns |  6.26 ns |  5.23 ns |  0.89 |    0.01 | 0.9670 |     - |     - |    2024 B |
-|            Hyperlinq |   100 | 1,284.6 ns |  8.16 ns |  7.63 ns |  1.33 |    0.02 | 0.9670 |     - |     - |    2024 B |
-|       Hyperlinq_Pool |   100 | 1,178.6 ns |  7.63 ns |  7.14 ns |  1.22 |    0.01 | 0.0267 |     - |     - |      56 B |
+|                                    Method | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|------------------------------------------ |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                        ValueLinq_Standard |   100 |  3.010 μs | 0.0261 μs | 0.0244 μs |  3.016 μs |  1.21 |    0.07 | 1.5717 |     - |     - |    6576 B |
+|                           ValueLinq_Stack |   100 |  1.988 μs | 0.0141 μs | 0.0117 μs |  1.989 μs |  0.80 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|                 ValueLinq_SharedPool_Push |   100 |  2.686 μs | 0.0242 μs | 0.0227 μs |  2.683 μs |  1.08 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|                 ValueLinq_SharedPool_Pull |   100 |  2.397 μs | 0.0326 μs | 0.0272 μs |  2.400 μs |  0.97 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|                    ValueLinq_Ref_Standard |   100 |  2.969 μs | 0.0259 μs | 0.0242 μs |  2.965 μs |  1.20 |    0.07 | 1.5717 |     - |     - |    6576 B |
+|                       ValueLinq_Ref_Stack |   100 |  1.913 μs | 0.0365 μs | 0.0391 μs |  1.922 μs |  0.77 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|             ValueLinq_Ref_SharedPool_Push |   100 |  2.539 μs | 0.0506 μs | 0.0541 μs |  2.548 μs |  1.02 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|             ValueLinq_Ref_SharedPool_Pull |   100 |  2.317 μs | 0.0454 μs | 0.0746 μs |  2.329 μs |  0.94 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|            ValueLinq_ValueLambda_Standard |   100 |  2.663 μs | 0.0519 μs | 0.0867 μs |  2.664 μs |  1.07 |    0.07 | 1.5717 |     - |     - |    6576 B |
+|               ValueLinq_ValueLambda_Stack |   100 |  2.139 μs | 0.0421 μs | 0.0870 μs |  2.146 μs |  0.86 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|     ValueLinq_ValueLambda_SharedPool_Push |   100 |  2.439 μs | 0.0486 μs | 0.1117 μs |  2.452 μs |  0.98 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|     ValueLinq_ValueLambda_SharedPool_Pull |   100 |  2.473 μs | 0.0493 μs | 0.1421 μs |  2.479 μs |  0.99 |    0.08 | 0.4807 |     - |     - |    2024 B |
+|        ValueLinq_ValueLambda_Ref_Standard |   100 |  2.933 μs | 0.0588 μs | 0.1538 μs |  2.945 μs |  1.18 |    0.09 | 1.5717 |     - |     - |    6576 B |
+|           ValueLinq_ValueLambda_Ref_Stack |   100 |  2.070 μs | 0.0422 μs | 0.1246 μs |  2.090 μs |  0.84 |    0.07 | 0.4807 |     - |     - |    2024 B |
+| ValueLinq_ValueLambda_Ref_SharedPool_Push |   100 |  2.563 μs | 0.0512 μs | 0.1302 μs |  2.580 μs |  1.03 |    0.08 | 0.4807 |     - |     - |    2024 B |
+| ValueLinq_ValueLambda_Ref_SharedPool_Pull |   100 |  2.388 μs | 0.0477 μs | 0.1196 μs |  2.405 μs |  0.96 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|                                   ForLoop |   100 |  2.493 μs | 0.0500 μs | 0.1299 μs |  2.506 μs |  1.00 |    0.00 | 1.7052 |     - |     - |    7136 B |
+|                               ForeachLoop |   100 |  2.639 μs | 0.0528 μs | 0.1256 μs |  2.678 μs |  1.06 |    0.07 | 1.7052 |     - |     - |    7136 B |
+|                                      Linq |   100 |  2.997 μs | 0.0595 μs | 0.1342 μs |  3.039 μs |  1.21 |    0.09 | 1.2131 |     - |     - |    5088 B |
+|                                LinqFaster |   100 |  2.384 μs | 0.0474 μs | 0.1391 μs |  2.400 μs |  0.96 |    0.07 | 1.4420 |     - |     - |    6048 B |
+|                                    LinqAF |   100 | 12.416 μs | 0.5270 μs | 1.4066 μs | 12.100 μs |  5.01 |    0.66 |      - |     - |     - |    7104 B |
+|                                StructLinq |   100 |  2.483 μs | 0.0495 μs | 0.1338 μs |  2.469 μs |  1.00 |    0.08 | 0.5035 |     - |     - |    2120 B |
+|                      StructLinq_IFunction |   100 |  1.870 μs | 0.0376 μs | 0.1072 μs |  1.901 μs |  0.75 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|                                 Hyperlinq |   100 |  2.502 μs | 0.0496 μs | 0.1463 μs |  2.514 μs |  1.00 |    0.08 | 0.4807 |     - |     - |    2024 B |
+|                            Hyperlinq_Pool |   100 |  2.343 μs | 0.0462 μs | 0.0975 μs |  2.343 μs |  0.95 |    0.06 | 0.0114 |     - |     - |      56 B |

--- a/Results/Array.ValueType.ArrayValueTypeWhereSelectToList.md
+++ b/Results/Array.ValueType.ArrayValueTypeWhereSelectToList.md
@@ -12,22 +12,38 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 |   823.7 ns |  9.36 ns |  8.29 ns |  1.00 |    0.00 | 2.4433 |     - |     - |   4.99 KB |
-|          ForeachLoop |   100 |   880.9 ns |  4.82 ns |  4.28 ns |  1.07 |    0.01 | 2.4433 |     - |     - |   4.99 KB |
-|                 Linq |   100 | 1,262.8 ns |  7.14 ns |  6.33 ns |  1.53 |    0.02 | 2.5234 |     - |     - |   5.16 KB |
-|           LinqFaster |   100 | 1,196.9 ns |  7.31 ns |  6.48 ns |  1.45 |    0.01 | 3.8700 |     - |     - |   7.91 KB |
-|               LinqAF |   100 | 1,931.4 ns | 18.75 ns | 15.66 ns |  2.34 |    0.02 | 2.4414 |     - |     - |   4.99 KB |
-|           StructLinq |   100 | 1,306.9 ns |  6.48 ns |  5.75 ns |  1.59 |    0.02 | 1.0281 |     - |     - |    2.1 KB |
-| StructLinq_IFunction |   100 |   880.2 ns | 17.12 ns | 16.01 ns |  1.07 |    0.02 | 0.9823 |     - |     - |   2.01 KB |
-|            Hyperlinq |   100 | 1,295.2 ns | 12.39 ns | 11.59 ns |  1.57 |    0.03 | 1.0166 |     - |     - |   2.08 KB |
+|                                    Method | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|------------------------------------------ |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                        ValueLinq_Standard |   100 |  2.833 μs | 0.0557 μs | 0.1059 μs |  2.855 μs |  1.37 |    0.07 | 1.2207 |     - |     - |   4.99 KB |
+|                           ValueLinq_Stack |   100 |  2.474 μs | 0.0495 μs | 0.1117 μs |  2.502 μs |  1.20 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|                 ValueLinq_SharedPool_Push |   100 |  3.234 μs | 0.0648 μs | 0.1450 μs |  3.227 μs |  1.56 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|                 ValueLinq_SharedPool_Pull |   100 |  3.095 μs | 0.0619 μs | 0.1359 μs |  3.096 μs |  1.50 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+|                    ValueLinq_Ref_Standard |   100 |  3.025 μs | 0.0607 μs | 0.1369 μs |  3.024 μs |  1.46 |    0.09 | 1.2207 |     - |     - |   4.99 KB |
+|                       ValueLinq_Ref_Stack |   100 |  2.686 μs | 0.0531 μs | 0.1262 μs |  2.688 μs |  1.30 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|             ValueLinq_Ref_SharedPool_Push |   100 |  3.185 μs | 0.0628 μs | 0.1391 μs |  3.197 μs |  1.54 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+|             ValueLinq_Ref_SharedPool_Pull |   100 |  2.986 μs | 0.0598 μs | 0.1764 μs |  2.971 μs |  1.45 |    0.11 | 0.4883 |     - |     - |   2.01 KB |
+|            ValueLinq_ValueLambda_Standard |   100 |  2.639 μs | 0.0528 μs | 0.1223 μs |  2.641 μs |  1.28 |    0.08 | 1.2207 |     - |     - |   4.99 KB |
+|               ValueLinq_ValueLambda_Stack |   100 |  2.712 μs | 0.0542 μs | 0.1400 μs |  2.703 μs |  1.31 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+|     ValueLinq_ValueLambda_SharedPool_Push |   100 |  2.875 μs | 0.0571 μs | 0.0985 μs |  2.885 μs |  1.39 |    0.07 | 0.4883 |     - |     - |   2.01 KB |
+|     ValueLinq_ValueLambda_SharedPool_Pull |   100 |  2.873 μs | 0.0571 μs | 0.1506 μs |  2.892 μs |  1.39 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+|        ValueLinq_ValueLambda_Ref_Standard |   100 |  2.514 μs | 0.0503 μs | 0.1062 μs |  2.529 μs |  1.21 |    0.07 | 1.2207 |     - |     - |   4.99 KB |
+|           ValueLinq_ValueLambda_Ref_Stack |   100 |  2.618 μs | 0.0761 μs | 0.2244 μs |  2.679 μs |  1.20 |    0.13 | 0.4883 |     - |     - |   2.01 KB |
+| ValueLinq_ValueLambda_Ref_SharedPool_Push |   100 |  2.718 μs | 0.0543 μs | 0.1280 μs |  2.718 μs |  1.32 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+| ValueLinq_ValueLambda_Ref_SharedPool_Pull |   100 |  2.601 μs | 0.0521 μs | 0.1327 μs |  2.634 μs |  1.26 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+|                                   ForLoop |   100 |  2.070 μs | 0.0408 μs | 0.0815 μs |  2.081 μs |  1.00 |    0.00 | 1.2207 |     - |     - |   4.99 KB |
+|                               ForeachLoop |   100 |  2.152 μs | 0.0413 μs | 0.0835 μs |  2.166 μs |  1.04 |    0.06 | 1.2207 |     - |     - |   4.99 KB |
+|                                      Linq |   100 |  3.046 μs | 0.0609 μs | 0.1423 μs |  3.060 μs |  1.48 |    0.10 | 1.2589 |     - |     - |   5.16 KB |
+|                                LinqFaster |   100 |  2.976 μs | 0.0592 μs | 0.1430 μs |  2.993 μs |  1.43 |    0.08 | 1.9341 |     - |     - |   7.91 KB |
+|                                    LinqAF |   100 | 12.698 μs | 0.5581 μs | 1.5183 μs | 12.300 μs |  6.26 |    0.87 |      - |     - |     - |   4.99 KB |
+|                                StructLinq |   100 |  2.550 μs | 0.0509 μs | 0.1085 μs |  2.533 μs |  1.24 |    0.08 | 0.5112 |     - |     - |    2.1 KB |
+|                      StructLinq_IFunction |   100 |  1.874 μs | 0.0373 μs | 0.0710 μs |  1.874 μs |  0.91 |    0.05 | 0.4902 |     - |     - |   2.01 KB |
+|                                 Hyperlinq |   100 |  2.753 μs | 0.0548 μs | 0.1168 μs |  2.757 μs |  1.33 |    0.08 | 0.5074 |     - |     - |   2.08 KB |

--- a/Results/Enumerable.Int32.EnumerableInt32WhereSelectToArray.md
+++ b/Results/Enumerable.Int32.EnumerableInt32WhereSelectToArray.md
@@ -12,21 +12,29 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |    Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|---------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|          ForeachLoop |   100 |   669.5 ns |  5.07 ns | 4.74 ns |  1.00 |    0.00 | 0.4358 |     - |     - |     912 B |
-|                 Linq |   100 | 1,080.9 ns | 10.11 ns | 9.46 ns |  1.61 |    0.02 | 0.3967 |     - |     - |     832 B |
-|               LinqAF |   100 | 1,268.5 ns |  9.92 ns | 9.28 ns |  1.89 |    0.01 | 0.4177 |     - |     - |     880 B |
-|           StructLinq |   100 | 1,126.8 ns | 10.68 ns | 9.99 ns |  1.68 |    0.02 | 0.1678 |     - |     - |     352 B |
-| StructLinq_IFunction |   100 |   747.8 ns |  3.15 ns | 2.79 ns |  1.12 |    0.01 | 0.1259 |     - |     - |     264 B |
-|            Hyperlinq |   100 | 1,047.9 ns |  6.04 ns | 5.35 ns |  1.57 |    0.02 | 0.1259 |     - |     - |     264 B |
-|       Hyperlinq_Pool |   100 | 1,129.6 ns |  8.83 ns | 8.26 ns |  1.69 |    0.02 | 0.0458 |     - |     - |      96 B |
+|                                Method | Count |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------- |------ |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                    ValueLinq_Standard |   100 | 2.262 μs | 0.0449 μs | 0.1040 μs |  1.73 |    0.11 | 0.1869 |     - |     - |     784 B |
+|                       ValueLinq_Stack |   100 | 1.846 μs | 0.0387 μs | 0.1142 μs |  1.41 |    0.11 | 0.0610 |     - |     - |     264 B |
+|             ValueLinq_SharedPool_Push |   100 | 2.320 μs | 0.0465 μs | 0.1088 μs |  1.79 |    0.12 | 0.0610 |     - |     - |     264 B |
+|             ValueLinq_SharedPool_Pull |   100 | 2.200 μs | 0.0441 μs | 0.1170 μs |  1.69 |    0.12 | 0.0610 |     - |     - |     264 B |
+|        ValueLinq_ValueLambda_Standard |   100 | 1.977 μs | 0.0394 μs | 0.1143 μs |  1.50 |    0.11 | 0.1869 |     - |     - |     784 B |
+|           ValueLinq_ValueLambda_Stack |   100 | 1.334 μs | 0.0264 μs | 0.0527 μs |  1.02 |    0.06 | 0.0629 |     - |     - |     264 B |
+| ValueLinq_ValueLambda_SharedPool_Push |   100 | 1.786 μs | 0.0352 μs | 0.0671 μs |  1.37 |    0.08 | 0.0629 |     - |     - |     264 B |
+| ValueLinq_ValueLambda_SharedPool_Pull |   100 | 1.686 μs | 0.0333 μs | 0.0724 μs |  1.30 |    0.07 | 0.0629 |     - |     - |     264 B |
+|                           ForeachLoop |   100 | 1.304 μs | 0.0257 μs | 0.0508 μs |  1.00 |    0.00 | 0.2174 |     - |     - |     912 B |
+|                                  Linq |   100 | 2.022 μs | 0.0438 μs | 0.1277 μs |  1.49 |    0.10 | 0.1984 |     - |     - |     832 B |
+|                                LinqAF |   100 | 9.207 μs | 0.4012 μs | 1.0914 μs |  7.24 |    0.85 |      - |     - |     - |     880 B |
+|                            StructLinq |   100 | 2.054 μs | 0.0385 μs | 0.0643 μs |  1.58 |    0.09 | 0.0839 |     - |     - |     352 B |
+|                  StructLinq_IFunction |   100 | 1.533 μs | 0.0301 μs | 0.0551 μs |  1.18 |    0.06 | 0.0629 |     - |     - |     264 B |
+|                             Hyperlinq |   100 | 2.103 μs | 0.0420 μs | 0.1022 μs |  1.62 |    0.10 | 0.0610 |     - |     - |     264 B |
+|                        Hyperlinq_Pool |   100 | 2.127 μs | 0.0423 μs | 0.0845 μs |  1.63 |    0.10 | 0.0229 |     - |     - |      96 B |

--- a/Results/Enumerable.Int32.EnumerableInt32WhereSelectToList.md
+++ b/Results/Enumerable.Int32.EnumerableInt32WhereSelectToList.md
@@ -12,20 +12,28 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|          ForeachLoop |   100 |   659.9 ns | 11.70 ns | 10.94 ns |  1.00 |    0.00 | 0.3281 |     - |     - |     688 B |
-|                 Linq |   100 | 1,028.0 ns |  7.33 ns |  6.49 ns |  1.56 |    0.03 | 0.3853 |     - |     - |     808 B |
-|               LinqAF |   100 | 1,257.9 ns |  6.16 ns |  5.46 ns |  1.90 |    0.03 | 0.3281 |     - |     - |     688 B |
-|           StructLinq |   100 | 1,189.7 ns |  7.34 ns |  6.13 ns |  1.80 |    0.03 | 0.1831 |     - |     - |     384 B |
-| StructLinq_IFunction |   100 |   751.8 ns |  4.33 ns |  3.84 ns |  1.14 |    0.02 | 0.1411 |     - |     - |     296 B |
-|            Hyperlinq |   100 | 1,120.8 ns |  7.63 ns |  6.76 ns |  1.70 |    0.03 | 0.1755 |     - |     - |     368 B |
+|                                Method | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------- |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                    ValueLinq_Standard |   100 |  1.726 μs | 0.0341 μs | 0.0656 μs |  1.734 μs |  1.17 |    0.07 | 0.1640 |     - |     - |     688 B |
+|                       ValueLinq_Stack |   100 |  1.996 μs | 0.0400 μs | 0.0809 μs |  2.038 μs |  1.35 |    0.09 | 0.0687 |     - |     - |     296 B |
+|             ValueLinq_SharedPool_Push |   100 |  2.341 μs | 0.0468 μs | 0.0756 μs |  2.373 μs |  1.57 |    0.10 | 0.0687 |     - |     - |     296 B |
+|             ValueLinq_SharedPool_Pull |   100 |  2.248 μs | 0.0447 μs | 0.1104 μs |  2.237 μs |  1.51 |    0.10 | 0.0687 |     - |     - |     296 B |
+|        ValueLinq_ValueLambda_Standard |   100 |  1.538 μs | 0.0307 μs | 0.0759 μs |  1.558 μs |  1.04 |    0.08 | 0.1640 |     - |     - |     688 B |
+|           ValueLinq_ValueLambda_Stack |   100 |  1.710 μs | 0.0339 μs | 0.0594 μs |  1.708 μs |  1.15 |    0.06 | 0.0706 |     - |     - |     296 B |
+| ValueLinq_ValueLambda_SharedPool_Push |   100 |  2.196 μs | 0.0436 μs | 0.0975 μs |  2.198 μs |  1.49 |    0.11 | 0.0687 |     - |     - |     296 B |
+| ValueLinq_ValueLambda_SharedPool_Pull |   100 |  2.121 μs | 0.0425 μs | 0.1082 μs |  2.157 μs |  1.43 |    0.10 | 0.0687 |     - |     - |     296 B |
+|                           ForeachLoop |   100 |  1.488 μs | 0.0299 μs | 0.0721 μs |  1.501 μs |  1.00 |    0.00 | 0.1640 |     - |     - |     688 B |
+|                                  Linq |   100 |  2.192 μs | 0.0545 μs | 0.1598 μs |  2.187 μs |  1.45 |    0.12 | 0.1907 |     - |     - |     808 B |
+|                                LinqAF |   100 | 13.281 μs | 1.0720 μs | 3.0060 μs | 11.900 μs |  8.89 |    2.09 |      - |     - |     - |     688 B |
+|                            StructLinq |   100 |  2.364 μs | 0.0467 μs | 0.1025 μs |  2.352 μs |  1.59 |    0.10 | 0.0916 |     - |     - |     384 B |
+|                  StructLinq_IFunction |   100 |  1.467 μs | 0.0294 μs | 0.0823 μs |  1.479 μs |  0.98 |    0.07 | 0.0706 |     - |     - |     296 B |
+|                             Hyperlinq |   100 |  2.180 μs | 0.0433 μs | 0.1038 μs |  2.194 μs |  1.47 |    0.10 | 0.0877 |     - |     - |     368 B |

--- a/Results/List.Int32.ListInt32WhereSelectToArray.md
+++ b/Results/List.Int32.ListInt32WhereSelectToArray.md
@@ -12,23 +12,39 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 |   266.2 ns | 3.65 ns | 3.23 ns |  1.00 |    0.00 | 0.4168 |     - |     - |     872 B |
-|          ForeachLoop |   100 |   409.2 ns | 3.62 ns | 3.21 ns |  1.54 |    0.03 | 0.4168 |     - |     - |     872 B |
-|                 Linq |   100 |   583.9 ns | 4.33 ns | 4.05 ns |  2.19 |    0.03 | 0.3939 |     - |     - |     824 B |
-|           LinqFaster |   100 |   553.1 ns | 3.48 ns | 3.08 ns |  2.08 |    0.03 | 0.4168 |     - |     - |     872 B |
-|               LinqAF |   100 | 1,226.2 ns | 7.56 ns | 6.31 ns |  4.61 |    0.06 | 0.4005 |     - |     - |     840 B |
-|           StructLinq |   100 |   674.2 ns | 4.44 ns | 3.94 ns |  2.53 |    0.03 | 0.1564 |     - |     - |     328 B |
-| StructLinq_IFunction |   100 |   364.5 ns | 2.04 ns | 1.91 ns |  1.37 |    0.02 | 0.1068 |     - |     - |     224 B |
-|            Hyperlinq |   100 |   634.9 ns | 3.59 ns | 3.18 ns |  2.39 |    0.03 | 0.1068 |     - |     - |     224 B |
-|       Hyperlinq_Pool |   100 |   689.9 ns | 5.13 ns | 4.55 ns |  2.59 |    0.04 | 0.0267 |     - |     - |      56 B |
+|                                        Method | Count |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|---------------------------------------------- |------ |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
+|                            ValueLinq_Standard |   100 | 1,579.3 ns |  31.41 ns |  81.08 ns | 1,592.8 ns |  2.17 |    0.17 | 0.1774 |     - |     - |     744 B |
+|                               ValueLinq_Stack |   100 | 1,536.5 ns |  30.37 ns |  64.05 ns | 1,551.6 ns |  2.12 |    0.15 | 0.0534 |     - |     - |     224 B |
+|                     ValueLinq_SharedPool_Push |   100 | 1,646.8 ns |  32.82 ns |  84.14 ns | 1,654.8 ns |  2.27 |    0.16 | 0.0534 |     - |     - |     224 B |
+|                     ValueLinq_SharedPool_Pull |   100 | 1,915.3 ns |  38.26 ns | 106.01 ns | 1,935.3 ns |  2.64 |    0.22 | 0.0534 |     - |     - |     224 B |
+|                ValueLinq_ValueLambda_Standard |   100 | 1,372.6 ns |  27.30 ns |  77.01 ns | 1,390.9 ns |  1.89 |    0.16 | 0.1774 |     - |     - |     744 B |
+|                   ValueLinq_ValueLambda_Stack |   100 | 1,272.1 ns |  25.43 ns |  67.00 ns | 1,293.2 ns |  1.75 |    0.15 | 0.0534 |     - |     - |     224 B |
+|         ValueLinq_ValueLambda_SharedPool_Push |   100 | 1,416.2 ns |  28.38 ns |  82.78 ns | 1,432.0 ns |  1.95 |    0.17 | 0.0534 |     - |     - |     224 B |
+|         ValueLinq_ValueLambda_SharedPool_Pull |   100 | 1,614.6 ns |  32.55 ns |  95.96 ns | 1,628.1 ns |  2.22 |    0.19 | 0.0534 |     - |     - |     224 B |
+|                    ValueLinq_Standard_ByIndex |   100 | 1,303.9 ns |  26.69 ns |  78.68 ns | 1,348.9 ns |  1.80 |    0.14 | 0.1774 |     - |     - |     744 B |
+|                       ValueLinq_Stack_ByIndex |   100 |   982.2 ns |  21.84 ns |  64.39 ns | 1,020.5 ns |  1.35 |    0.12 | 0.0534 |     - |     - |     224 B |
+|             ValueLinq_SharedPool_Push_ByIndex |   100 | 1,276.1 ns |  25.55 ns |  74.94 ns | 1,240.8 ns |  1.76 |    0.14 | 0.0534 |     - |     - |     224 B |
+|             ValueLinq_SharedPool_Pull_ByIndex |   100 | 1,247.5 ns |  25.02 ns |  71.78 ns | 1,215.3 ns |  1.72 |    0.15 | 0.0534 |     - |     - |     224 B |
+|        ValueLinq_ValueLambda_Standard_ByIndex |   100 | 1,050.8 ns |  21.69 ns |  63.95 ns | 1,078.6 ns |  1.45 |    0.11 | 0.1774 |     - |     - |     744 B |
+|           ValueLinq_ValueLambda_Stack_ByIndex |   100 |   604.9 ns |  13.63 ns |  40.19 ns |   629.9 ns |  0.83 |    0.07 | 0.0534 |     - |     - |     224 B |
+| ValueLinq_ValueLambda_SharedPool_Push_ByIndex |   100 | 1,071.4 ns |  23.60 ns |  69.58 ns | 1,044.3 ns |  1.48 |    0.15 | 0.0534 |     - |     - |     224 B |
+| ValueLinq_ValueLambda_SharedPool_Pull_ByIndex |   100 |   951.4 ns |  19.10 ns |  53.88 ns |   939.7 ns |  1.31 |    0.11 | 0.0534 |     - |     - |     224 B |
+|                                       ForLoop |   100 |   728.4 ns |  14.95 ns |  44.08 ns |   740.9 ns |  1.00 |    0.00 | 0.2079 |     - |     - |     872 B |
+|                                   ForeachLoop |   100 |   969.3 ns |  22.11 ns |  65.20 ns |   989.2 ns |  1.34 |    0.13 | 0.2079 |     - |     - |     872 B |
+|                                          Linq |   100 | 1,146.1 ns |  25.34 ns |  74.71 ns | 1,168.0 ns |  1.58 |    0.14 | 0.1965 |     - |     - |     824 B |
+|                                    LinqFaster |   100 |   960.8 ns |  22.05 ns |  65.02 ns |   974.2 ns |  1.32 |    0.13 | 0.2079 |     - |     - |     872 B |
+|                                        LinqAF |   100 | 8,074.7 ns | 161.47 ns | 408.06 ns | 7,900.0 ns | 11.13 |    0.93 |      - |     - |     - |     840 B |
+|                                    StructLinq |   100 | 1,080.2 ns |  22.68 ns |  66.87 ns | 1,049.6 ns |  1.49 |    0.13 | 0.0782 |     - |     - |     328 B |
+|                          StructLinq_IFunction |   100 |   821.1 ns |  17.24 ns |  50.85 ns |   814.6 ns |  1.13 |    0.10 | 0.0534 |     - |     - |     224 B |
+|                                     Hyperlinq |   100 | 1,038.7 ns |  20.64 ns |  59.89 ns | 1,011.3 ns |  1.43 |    0.12 | 0.0534 |     - |     - |     224 B |
+|                                Hyperlinq_Pool |   100 | 1,163.0 ns |  23.27 ns |  68.23 ns | 1,130.5 ns |  1.60 |    0.13 | 0.0134 |     - |     - |      56 B |

--- a/Results/List.Int32.ListInt32WhereSelectToList.md
+++ b/Results/List.Int32.ListInt32WhereSelectToList.md
@@ -12,22 +12,38 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 |   248.9 ns | 1.18 ns | 0.99 ns |  1.00 |    0.00 | 0.3095 |     - |     - |     648 B |
-|          ForeachLoop |   100 |   464.6 ns | 1.68 ns | 1.49 ns |  1.87 |    0.01 | 0.3095 |     - |     - |     648 B |
-|                 Linq |   100 |   553.4 ns | 2.45 ns | 2.17 ns |  2.22 |    0.01 | 0.3824 |     - |     - |     800 B |
-|           LinqFaster |   100 |   591.5 ns | 4.47 ns | 3.96 ns |  2.38 |    0.02 | 0.4320 |     - |     - |     904 B |
-|               LinqAF |   100 | 1,199.6 ns | 8.94 ns | 8.36 ns |  4.81 |    0.03 | 0.3090 |     - |     - |     648 B |
-|           StructLinq |   100 |   656.7 ns | 4.71 ns | 4.40 ns |  2.64 |    0.02 | 0.1717 |     - |     - |     360 B |
-| StructLinq_IFunction |   100 |   374.3 ns | 2.26 ns | 2.00 ns |  1.50 |    0.01 | 0.1221 |     - |     - |     256 B |
-|            Hyperlinq |   100 |   665.3 ns | 4.51 ns | 3.77 ns |  2.67 |    0.02 | 0.1564 |     - |     - |     328 B |
+|                                        Method | Count |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|---------------------------------------------- |------ |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
+|                            ValueLinq_Standard |   100 | 1,294.7 ns |   6.45 ns |   5.72 ns | 1,293.6 ns |  1.97 |    0.13 | 0.1545 |     - |     - |     648 B |
+|                               ValueLinq_Stack |   100 | 1,544.5 ns |   6.77 ns |   6.33 ns | 1,541.8 ns |  2.34 |    0.16 | 0.0610 |     - |     - |     256 B |
+|                     ValueLinq_SharedPool_Push |   100 | 1,637.9 ns |  14.14 ns |  13.23 ns | 1,630.5 ns |  2.48 |    0.17 | 0.0610 |     - |     - |     256 B |
+|                     ValueLinq_SharedPool_Pull |   100 | 1,952.1 ns |   7.32 ns |   5.71 ns | 1,954.8 ns |  3.00 |    0.20 | 0.0610 |     - |     - |     256 B |
+|                ValueLinq_ValueLambda_Standard |   100 | 1,110.0 ns |   6.35 ns |   5.94 ns | 1,108.3 ns |  1.68 |    0.12 | 0.1545 |     - |     - |     648 B |
+|                   ValueLinq_ValueLambda_Stack |   100 | 1,326.4 ns |  24.46 ns |  22.88 ns | 1,339.3 ns |  2.01 |    0.13 | 0.0610 |     - |     - |     256 B |
+|         ValueLinq_ValueLambda_SharedPool_Push |   100 | 1,469.0 ns |  25.35 ns |  23.71 ns | 1,456.6 ns |  2.23 |    0.15 | 0.0610 |     - |     - |     256 B |
+|         ValueLinq_ValueLambda_SharedPool_Pull |   100 | 1,667.6 ns |  33.40 ns |  41.02 ns | 1,689.5 ns |  2.51 |    0.18 | 0.0610 |     - |     - |     256 B |
+|                    ValueLinq_Standard_ByIndex |   100 |   987.7 ns |  19.76 ns |  27.04 ns |   999.4 ns |  1.49 |    0.10 | 0.1545 |     - |     - |     648 B |
+|                       ValueLinq_Stack_ByIndex |   100 | 1,076.1 ns |  21.36 ns |  40.63 ns | 1,071.9 ns |  1.62 |    0.11 | 0.0610 |     - |     - |     256 B |
+|             ValueLinq_SharedPool_Push_ByIndex |   100 | 1,424.9 ns |  28.47 ns |  68.22 ns | 1,436.3 ns |  2.15 |    0.16 | 0.0610 |     - |     - |     256 B |
+|             ValueLinq_SharedPool_Pull_ByIndex |   100 | 1,390.8 ns |  27.39 ns |  55.33 ns | 1,415.1 ns |  2.10 |    0.12 | 0.0610 |     - |     - |     256 B |
+|        ValueLinq_ValueLambda_Standard_ByIndex |   100 |   820.5 ns |  16.23 ns |  29.67 ns |   833.8 ns |  1.24 |    0.09 | 0.1545 |     - |     - |     648 B |
+|           ValueLinq_ValueLambda_Stack_ByIndex |   100 |   808.8 ns |  16.21 ns |  37.24 ns |   817.9 ns |  1.22 |    0.09 | 0.0610 |     - |     - |     256 B |
+| ValueLinq_ValueLambda_SharedPool_Push_ByIndex |   100 | 1,220.4 ns |  24.47 ns |  60.04 ns | 1,232.7 ns |  1.84 |    0.13 | 0.0610 |     - |     - |     256 B |
+| ValueLinq_ValueLambda_SharedPool_Pull_ByIndex |   100 | 1,140.5 ns |  22.89 ns |  61.87 ns | 1,151.9 ns |  1.72 |    0.14 | 0.0610 |     - |     - |     256 B |
+|                                       ForLoop |   100 |   665.0 ns |  13.41 ns |  34.12 ns |   674.4 ns |  1.00 |    0.00 | 0.1545 |     - |     - |     648 B |
+|                                   ForeachLoop |   100 |   907.4 ns |  18.04 ns |  44.93 ns |   920.2 ns |  1.37 |    0.10 | 0.1545 |     - |     - |     648 B |
+|                                          Linq |   100 | 1,092.2 ns |  21.97 ns |  59.41 ns | 1,116.6 ns |  1.65 |    0.13 | 0.1907 |     - |     - |     800 B |
+|                                    LinqFaster |   100 | 1,011.9 ns |  20.01 ns |  51.66 ns | 1,019.8 ns |  1.52 |    0.10 | 0.2155 |     - |     - |     904 B |
+|                                        LinqAF |   100 | 8,590.6 ns | 185.70 ns | 502.05 ns | 8,500.0 ns | 12.87 |    1.01 |      - |     - |     - |     648 B |
+|                                    StructLinq |   100 | 1,109.4 ns |  21.91 ns |  57.34 ns | 1,129.8 ns |  1.68 |    0.12 | 0.0858 |     - |     - |     360 B |
+|                          StructLinq_IFunction |   100 |   830.4 ns |  16.63 ns |  45.53 ns |   847.9 ns |  1.25 |    0.10 | 0.0610 |     - |     - |     256 B |
+|                                     Hyperlinq |   100 | 1,125.2 ns |  22.11 ns |  44.66 ns | 1,146.2 ns |  1.70 |    0.11 | 0.0782 |     - |     - |     328 B |

--- a/Results/List.ValueType.ListValueTypeWhereSelectToArray.md
+++ b/Results/List.ValueType.ListValueTypeWhereSelectToArray.md
@@ -12,23 +12,55 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 | 1,063.7 ns |  7.72 ns |  6.85 ns |  1.00 |    0.00 | 3.4103 |     - |     - |    7136 B |
-|          ForeachLoop |   100 | 1,288.7 ns |  9.94 ns |  8.81 ns |  1.21 |    0.01 | 3.4103 |     - |     - |    7136 B |
-|                 Linq |   100 | 1,365.1 ns | 13.61 ns | 12.73 ns |  1.28 |    0.01 | 2.4853 |     - |     - |    5200 B |
-|           LinqFaster |   100 | 1,405.8 ns | 19.61 ns | 17.39 ns |  1.32 |    0.02 | 3.4103 |     - |     - |    7136 B |
-|               LinqAF |   100 | 2,406.8 ns | 26.10 ns | 23.13 ns |  2.26 |    0.02 | 3.3951 |     - |     - |    7104 B |
-|           StructLinq |   100 | 1,275.1 ns |  6.91 ns |  6.13 ns |  1.20 |    0.01 | 1.0128 |     - |     - |    2120 B |
-| StructLinq_IFunction |   100 |   873.2 ns |  9.58 ns |  8.50 ns |  0.82 |    0.01 | 0.9670 |     - |     - |    2024 B |
-|            Hyperlinq |   100 | 1,243.3 ns |  8.98 ns |  8.40 ns |  1.17 |    0.01 | 0.9670 |     - |     - |    2024 B |
-|       Hyperlinq_Pool |   100 | 1,166.7 ns |  7.27 ns |  6.44 ns |  1.10 |    0.01 | 0.0267 |     - |     - |      56 B |
+|                                            Method | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------------------- |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                                ValueLinq_Standard |   100 |  3.798 μs | 0.0753 μs | 0.1278 μs |  3.805 μs |  1.69 |    0.06 | 1.5717 |     - |     - |    6576 B |
+|                                   ValueLinq_Stack |   100 |  2.609 μs | 0.0519 μs | 0.1106 μs |  2.643 μs |  1.18 |    0.04 | 0.4807 |     - |     - |    2024 B |
+|                         ValueLinq_SharedPool_Push |   100 |  3.582 μs | 0.0709 μs | 0.1333 μs |  3.635 μs |  1.62 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|                         ValueLinq_SharedPool_Pull |   100 |  3.125 μs | 0.0624 μs | 0.1471 μs |  3.210 μs |  1.41 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|                            ValueLinq_Ref_Standard |   100 |  3.717 μs | 0.0734 μs | 0.1596 μs |  3.761 μs |  1.67 |    0.08 | 1.5717 |     - |     - |    6576 B |
+|                               ValueLinq_Ref_Stack |   100 |  2.590 μs | 0.0519 μs | 0.1439 μs |  2.628 μs |  1.17 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|                     ValueLinq_Ref_SharedPool_Push |   100 |  3.440 μs | 0.0551 μs | 0.0460 μs |  3.452 μs |  1.54 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|                     ValueLinq_Ref_SharedPool_Pull |   100 |  3.022 μs | 0.0602 μs | 0.1688 μs |  3.087 μs |  1.36 |    0.09 | 0.4807 |     - |     - |    2024 B |
+|                    ValueLinq_ValueLambda_Standard |   100 |  3.146 μs | 0.0626 μs | 0.1413 μs |  3.195 μs |  1.43 |    0.07 | 1.5717 |     - |     - |    6576 B |
+|                       ValueLinq_ValueLambda_Stack |   100 |  2.665 μs | 0.0534 μs | 0.1387 μs |  2.716 μs |  1.20 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|             ValueLinq_ValueLambda_SharedPool_Push |   100 |  2.770 μs | 0.0555 μs | 0.1382 μs |  2.833 μs |  1.26 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|             ValueLinq_ValueLambda_SharedPool_Pull |   100 |  2.837 μs | 0.0566 μs | 0.1521 μs |  2.905 μs |  1.30 |    0.07 | 0.4807 |     - |     - |    2024 B |
+|                ValueLinq_ValueLambda_Ref_Standard |   100 |  2.782 μs | 0.0585 μs | 0.0650 μs |  2.803 μs |  1.25 |    0.04 | 1.5717 |     - |     - |    6576 B |
+|                   ValueLinq_ValueLambda_Ref_Stack |   100 |  2.251 μs | 0.0448 μs | 0.1039 μs |  2.288 μs |  1.03 |    0.04 | 0.4807 |     - |     - |    2024 B |
+|         ValueLinq_ValueLambda_Ref_SharedPool_Push |   100 |  2.417 μs | 0.0471 μs | 0.0484 μs |  2.432 μs |  1.08 |    0.03 | 0.4807 |     - |     - |    2024 B |
+|         ValueLinq_ValueLambda_Ref_SharedPool_Pull |   100 |  2.531 μs | 0.0503 μs | 0.1317 μs |  2.583 μs |  1.16 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|                        ValueLinq_Standard_ByIndex |   100 |  3.539 μs | 0.0706 μs | 0.0785 μs |  3.571 μs |  1.58 |    0.05 | 1.5717 |     - |     - |    6576 B |
+|                           ValueLinq_Stack_ByIndex |   100 |  2.025 μs | 0.0400 μs | 0.0912 μs |  2.047 μs |  0.92 |    0.04 | 0.4807 |     - |     - |    2024 B |
+|                 ValueLinq_SharedPool_Push_ByIndex |   100 |  3.076 μs | 0.0614 μs | 0.1562 μs |  3.124 μs |  1.39 |    0.08 | 0.4807 |     - |     - |    2024 B |
+|                 ValueLinq_SharedPool_Pull_ByIndex |   100 |  2.458 μs | 0.0486 μs | 0.1127 μs |  2.490 μs |  1.13 |    0.04 | 0.4807 |     - |     - |    2024 B |
+|                    ValueLinq_Ref_Standard_ByIndex |   100 |  3.219 μs | 0.0644 μs | 0.1467 μs |  3.270 μs |  1.46 |    0.07 | 1.5717 |     - |     - |    6576 B |
+|                       ValueLinq_Ref_Stack_ByIndex |   100 |  1.912 μs | 0.0380 μs | 0.0917 μs |  1.940 μs |  0.87 |    0.03 | 0.4807 |     - |     - |    2024 B |
+|             ValueLinq_Ref_SharedPool_Push_ByIndex |   100 |  2.914 μs | 0.0578 μs | 0.1244 μs |  2.964 μs |  1.32 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|             ValueLinq_Ref_SharedPool_Pull_ByIndex |   100 |  2.336 μs | 0.0464 μs | 0.1113 μs |  2.378 μs |  1.06 |    0.06 | 0.4807 |     - |     - |    2024 B |
+|            ValueLinq_ValueLambda_Standard_ByIndex |   100 |  2.604 μs | 0.0515 μs | 0.1130 μs |  2.639 μs |  1.18 |    0.06 | 1.5717 |     - |     - |    6576 B |
+|               ValueLinq_ValueLambda_Stack_ByIndex |   100 |  2.002 μs | 0.0400 μs | 0.0967 μs |  2.030 μs |  0.91 |    0.04 | 0.4807 |     - |     - |    2024 B |
+|     ValueLinq_ValueLambda_SharedPool_Push_ByIndex |   100 |  2.212 μs | 0.0443 μs | 0.1111 μs |  2.234 μs |  1.02 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|     ValueLinq_ValueLambda_SharedPool_Pull_ByIndex |   100 |  2.199 μs | 0.0439 μs | 0.0991 μs |  2.235 μs |  0.98 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|        ValueLinq_ValueLambda_Ref_Standard_ByIndex |   100 |  2.695 μs | 0.0515 μs | 0.0632 μs |  2.715 μs |  1.21 |    0.05 | 1.5717 |     - |     - |    6576 B |
+|           ValueLinq_ValueLambda_Ref_Stack_ByIndex |   100 |  1.689 μs | 0.0339 μs | 0.0715 μs |  1.711 μs |  0.76 |    0.04 | 0.4826 |     - |     - |    2024 B |
+| ValueLinq_ValueLambda_Ref_SharedPool_Push_ByIndex |   100 |  2.246 μs | 0.0447 μs | 0.0913 μs |  2.286 μs |  1.01 |    0.05 | 0.4807 |     - |     - |    2024 B |
+| ValueLinq_ValueLambda_Ref_SharedPool_Pull_ByIndex |   100 |  1.950 μs | 0.0388 μs | 0.0802 μs |  1.992 μs |  0.88 |    0.04 | 0.4807 |     - |     - |    2024 B |
+|                                           ForLoop |   100 |  2.233 μs | 0.0418 μs | 0.0448 μs |  2.247 μs |  1.00 |    0.00 | 1.7052 |     - |     - |    7136 B |
+|                                       ForeachLoop |   100 |  2.583 μs | 0.0514 μs | 0.1106 μs |  2.633 μs |  1.17 |    0.06 | 1.7052 |     - |     - |    7136 B |
+|                                              Linq |   100 |  2.767 μs | 0.0552 μs | 0.1268 μs |  2.823 μs |  1.26 |    0.06 | 1.2398 |     - |     - |    5200 B |
+|                                        LinqFaster |   100 |  2.895 μs | 0.0579 μs | 0.1259 μs |  2.921 μs |  1.31 |    0.06 | 1.7052 |     - |     - |    7136 B |
+|                                            LinqAF |   100 | 12.717 μs | 0.2367 μs | 0.6237 μs | 12.700 μs |  5.81 |    0.40 |      - |     - |     - |    7104 B |
+|                                        StructLinq |   100 |  2.194 μs | 0.0424 μs | 0.0622 μs |  2.208 μs |  0.98 |    0.04 | 0.5035 |     - |     - |    2120 B |
+|                              StructLinq_IFunction |   100 |  1.554 μs | 0.0311 μs | 0.0670 μs |  1.577 μs |  0.71 |    0.03 | 0.4826 |     - |     - |    2024 B |
+|                                         Hyperlinq |   100 |  2.142 μs | 0.0424 μs | 0.1055 μs |  2.164 μs |  0.96 |    0.05 | 0.4807 |     - |     - |    2024 B |
+|                                    Hyperlinq_Pool |   100 |  1.907 μs | 0.0381 μs | 0.1044 μs |  1.966 μs |  0.86 |    0.06 | 0.0076 |     - |     - |      56 B |

--- a/Results/List.ValueType.ListValueTypeWhereSelectToList.md
+++ b/Results/List.ValueType.ListValueTypeWhereSelectToList.md
@@ -12,22 +12,54 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Count |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |-----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |   100 |   923.2 ns |  7.10 ns |  6.64 ns |  1.00 |    0.00 | 2.4433 |     - |     - |   4.99 KB |
-|          ForeachLoop |   100 | 1,127.6 ns |  8.57 ns |  7.59 ns |  1.22 |    0.01 | 2.4433 |     - |     - |   4.99 KB |
-|                 Linq |   100 | 1,351.3 ns | 17.55 ns | 14.66 ns |  1.46 |    0.02 | 2.5768 |     - |     - |   5.27 KB |
-|           LinqFaster |   100 | 1,470.0 ns | 17.80 ns | 15.78 ns |  1.59 |    0.02 | 3.4237 |     - |     - |      7 KB |
-|               LinqAF |   100 | 2,274.9 ns | 24.75 ns | 19.32 ns |  2.47 |    0.02 | 2.4414 |     - |     - |   4.99 KB |
-|           StructLinq |   100 | 1,276.1 ns |  9.58 ns |  8.96 ns |  1.38 |    0.01 | 1.0281 |     - |     - |    2.1 KB |
-| StructLinq_IFunction |   100 |   870.6 ns |  6.53 ns |  6.11 ns |  0.94 |    0.01 | 0.9823 |     - |     - |   2.01 KB |
-|            Hyperlinq |   100 | 1,297.1 ns | 13.38 ns | 12.52 ns |  1.41 |    0.01 | 1.0166 |     - |     - |   2.08 KB |
+|                                            Method | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------------------- |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                                ValueLinq_Standard |   100 |  3.176 μs | 0.0063 μs | 0.0049 μs |  3.179 μs |  1.72 |    0.07 | 1.2207 |     - |     - |   4.99 KB |
+|                                   ValueLinq_Stack |   100 |  2.779 μs | 0.0376 μs | 0.0352 μs |  2.787 μs |  1.49 |    0.05 | 0.4883 |     - |     - |   2.01 KB |
+|                         ValueLinq_SharedPool_Push |   100 |  3.619 μs | 0.0552 μs | 0.0516 μs |  3.617 μs |  1.95 |    0.07 | 0.4883 |     - |     - |   2.01 KB |
+|                         ValueLinq_SharedPool_Pull |   100 |  3.094 μs | 0.0597 μs | 0.0734 μs |  3.130 μs |  1.65 |    0.07 | 0.4883 |     - |     - |   2.01 KB |
+|                            ValueLinq_Ref_Standard |   100 |  3.243 μs | 0.0635 μs | 0.0825 μs |  3.251 μs |  1.74 |    0.07 | 1.2207 |     - |     - |   4.99 KB |
+|                               ValueLinq_Ref_Stack |   100 |  4.235 μs | 0.0515 μs | 0.0482 μs |  4.250 μs |  2.28 |    0.09 | 0.4883 |     - |     - |   2.01 KB |
+|                     ValueLinq_Ref_SharedPool_Push |   100 |  3.443 μs | 0.0687 μs | 0.1927 μs |  3.436 μs |  1.86 |    0.11 | 0.4883 |     - |     - |   2.01 KB |
+|                     ValueLinq_Ref_SharedPool_Pull |   100 |  3.176 μs | 0.0637 μs | 0.1643 μs |  3.192 μs |  1.70 |    0.10 | 0.4883 |     - |     - |   2.01 KB |
+|                    ValueLinq_ValueLambda_Standard |   100 |  2.789 μs | 0.0552 μs | 0.0678 μs |  2.805 μs |  1.49 |    0.06 | 1.2207 |     - |     - |   4.99 KB |
+|                       ValueLinq_ValueLambda_Stack |   100 |  2.870 μs | 0.0573 μs | 0.1489 μs |  2.933 μs |  1.54 |    0.11 | 0.4883 |     - |     - |   2.01 KB |
+|             ValueLinq_ValueLambda_SharedPool_Push |   100 |  2.889 μs | 0.0578 μs | 0.1418 μs |  2.893 μs |  1.54 |    0.11 | 0.4883 |     - |     - |   2.01 KB |
+|             ValueLinq_ValueLambda_SharedPool_Pull |   100 |  3.065 μs | 0.0610 μs | 0.1413 μs |  3.087 μs |  1.65 |    0.11 | 0.4883 |     - |     - |   2.01 KB |
+|                ValueLinq_ValueLambda_Ref_Standard |   100 |  2.339 μs | 0.0468 μs | 0.0946 μs |  2.381 μs |  1.26 |    0.07 | 1.2207 |     - |     - |   4.99 KB |
+|                   ValueLinq_ValueLambda_Ref_Stack |   100 |  2.522 μs | 0.0505 μs | 0.1275 μs |  2.568 μs |  1.35 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|         ValueLinq_ValueLambda_Ref_SharedPool_Push |   100 |  2.568 μs | 0.0496 μs | 0.0695 μs |  2.596 μs |  1.38 |    0.06 | 0.4883 |     - |     - |   2.01 KB |
+|         ValueLinq_ValueLambda_Ref_SharedPool_Pull |   100 |  2.756 μs | 0.0552 μs | 0.1312 μs |  2.802 μs |  1.48 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|                        ValueLinq_Standard_ByIndex |   100 |  3.011 μs | 0.0597 μs | 0.1259 μs |  3.056 μs |  1.62 |    0.09 | 1.2207 |     - |     - |   4.99 KB |
+|                           ValueLinq_Stack_ByIndex |   100 |  2.249 μs | 0.0447 μs | 0.0981 μs |  2.288 μs |  1.20 |    0.07 | 0.4883 |     - |     - |   2.01 KB |
+|                 ValueLinq_SharedPool_Push_ByIndex |   100 |  3.173 μs | 0.0622 μs | 0.1169 μs |  3.225 μs |  1.70 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|                 ValueLinq_SharedPool_Pull_ByIndex |   100 |  2.576 μs | 0.0513 μs | 0.1455 μs |  2.627 μs |  1.40 |    0.08 | 0.4883 |     - |     - |   2.01 KB |
+|                    ValueLinq_Ref_Standard_ByIndex |   100 |  2.840 μs | 0.0565 μs | 0.1115 μs |  2.893 μs |  1.52 |    0.06 | 1.2207 |     - |     - |   4.99 KB |
+|                       ValueLinq_Ref_Stack_ByIndex |   100 |  2.081 μs | 0.0417 μs | 0.0991 μs |  2.111 μs |  1.12 |    0.06 | 0.4883 |     - |     - |   2.01 KB |
+|             ValueLinq_Ref_SharedPool_Push_ByIndex |   100 |  3.042 μs | 0.0293 μs | 0.0274 μs |  3.051 μs |  1.64 |    0.06 | 0.4883 |     - |     - |   2.01 KB |
+|             ValueLinq_Ref_SharedPool_Pull_ByIndex |   100 |  2.422 μs | 0.0481 μs | 0.1198 μs |  2.461 μs |  1.30 |    0.07 | 0.4883 |     - |     - |   2.01 KB |
+|            ValueLinq_ValueLambda_Standard_ByIndex |   100 |  2.226 μs | 0.0440 μs | 0.0848 μs |  2.271 μs |  1.20 |    0.05 | 1.2207 |     - |     - |   4.99 KB |
+|               ValueLinq_ValueLambda_Stack_ByIndex |   100 |  2.320 μs | 0.0460 μs | 0.0990 μs |  2.356 μs |  1.25 |    0.06 | 0.4883 |     - |     - |   2.01 KB |
+|     ValueLinq_ValueLambda_SharedPool_Push_ByIndex |   100 |  2.395 μs | 0.0478 μs | 0.1038 μs |  2.432 μs |  1.28 |    0.07 | 0.4883 |     - |     - |   2.01 KB |
+|     ValueLinq_ValueLambda_SharedPool_Pull_ByIndex |   100 |  2.309 μs | 0.0462 μs | 0.1167 μs |  2.323 μs |  1.25 |    0.05 | 0.4883 |     - |     - |   2.01 KB |
+|        ValueLinq_ValueLambda_Ref_Standard_ByIndex |   100 |  2.244 μs | 0.0332 μs | 0.0311 μs |  2.256 μs |  1.21 |    0.05 | 1.2207 |     - |     - |   4.99 KB |
+|           ValueLinq_ValueLambda_Ref_Stack_ByIndex |   100 |  1.938 μs | 0.0375 μs | 0.0432 μs |  1.954 μs |  1.04 |    0.04 | 0.4902 |     - |     - |   2.01 KB |
+| ValueLinq_ValueLambda_Ref_SharedPool_Push_ByIndex |   100 |  2.413 μs | 0.0475 μs | 0.0959 μs |  2.460 μs |  1.30 |    0.06 | 0.4883 |     - |     - |   2.01 KB |
+| ValueLinq_ValueLambda_Ref_SharedPool_Pull_ByIndex |   100 |  2.138 μs | 0.0423 μs | 0.0835 μs |  2.182 μs |  1.15 |    0.06 | 0.4883 |     - |     - |   2.01 KB |
+|                                           ForLoop |   100 |  1.870 μs | 0.0369 μs | 0.0586 μs |  1.897 μs |  1.00 |    0.00 | 1.2207 |     - |     - |   4.99 KB |
+|                                       ForeachLoop |   100 |  2.223 μs | 0.0390 μs | 0.0365 μs |  2.237 μs |  1.20 |    0.05 | 1.2207 |     - |     - |   4.99 KB |
+|                                              Linq |   100 |  2.789 μs | 0.0542 μs | 0.0685 μs |  2.815 μs |  1.49 |    0.06 | 1.2856 |     - |     - |   5.27 KB |
+|                                        LinqFaster |   100 |  2.936 μs | 0.0575 μs | 0.1051 μs |  2.951 μs |  1.58 |    0.08 | 1.7128 |     - |     - |      7 KB |
+|                                            LinqAF |   100 | 13.049 μs | 0.2390 μs | 0.4186 μs | 13.100 μs |  7.00 |    0.33 |      - |     - |     - |   4.99 KB |
+|                                        StructLinq |   100 |  2.150 μs | 0.0428 μs | 0.0941 μs |  2.188 μs |  1.14 |    0.06 | 0.5112 |     - |     - |    2.1 KB |
+|                              StructLinq_IFunction |   100 |  1.566 μs | 0.0314 μs | 0.0582 μs |  1.593 μs |  0.84 |    0.04 | 0.4902 |     - |     - |   2.01 KB |
+|                                         Hyperlinq |   100 |  2.230 μs | 0.0465 μs | 0.1370 μs |  2.219 μs |  1.18 |    0.04 | 0.5074 |     - |     - |   2.08 KB |

--- a/Results/Range.RangeSelectToArray.md
+++ b/Results/Range.RangeSelectToArray.md
@@ -12,22 +12,30 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Start | Count |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |------ |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |     0 |   100 |  86.72 ns | 0.293 ns | 0.260 ns |  1.00 |    0.00 | 0.2027 |     - |     - |     424 B |
-|                 Linq |     0 |   100 | 229.98 ns | 1.169 ns | 1.036 ns |  2.65 |    0.02 | 0.2446 |     - |     - |     512 B |
-|           LinqFaster |     0 |   100 | 285.70 ns | 2.418 ns | 2.262 ns |  3.29 |    0.03 | 0.4053 |     - |     - |     848 B |
-|               LinqAF |     0 |   100 | 861.86 ns | 5.305 ns | 4.703 ns |  9.94 |    0.06 | 0.7534 |     - |     - |    1576 B |
-|           StructLinq |     0 |   100 | 424.04 ns | 2.591 ns | 2.297 ns |  4.89 |    0.03 | 0.2141 |     - |     - |     448 B |
-| StructLinq_IFunction |     0 |   100 | 297.99 ns | 1.316 ns | 1.167 ns |  3.44 |    0.02 | 0.2027 |     - |     - |     424 B |
-|            Hyperlinq |     0 |   100 | 230.20 ns | 1.402 ns | 1.242 ns |  2.65 |    0.02 | 0.2027 |     - |     - |     424 B |
-|       Hyperlinq_Pool |     0 |   100 | 295.32 ns | 2.391 ns | 2.120 ns |  3.41 |    0.02 | 0.0267 |     - |     - |      56 B |
+|                                Method | Start | Count |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------- |------ |------ |-----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+|                    ValueLinq_Standard |     0 |   100 |   541.5 ns |  10.73 ns |  25.71 ns |  2.98 |    0.18 | 0.1011 |     - |     - |     424 B |
+|                       ValueLinq_Stack |     0 |   100 | 1,027.6 ns |  20.37 ns |  44.71 ns |  5.69 |    0.28 | 0.1583 |     - |     - |     664 B |
+|             ValueLinq_SharedPool_Push |     0 |   100 |   989.4 ns |  19.48 ns |  35.62 ns |  5.50 |    0.25 | 0.1011 |     - |     - |     424 B |
+|             ValueLinq_SharedPool_Pull |     0 |   100 | 1,106.9 ns |  22.01 ns |  51.00 ns |  6.15 |    0.31 | 0.1011 |     - |     - |     424 B |
+|        ValueLinq_ValueLambda_Standard |     0 |   100 |   417.1 ns |   8.29 ns |  15.58 ns |  2.30 |    0.13 | 0.1011 |     - |     - |     424 B |
+|           ValueLinq_ValueLambda_Stack |     0 |   100 |   828.4 ns |  16.55 ns |  36.33 ns |  4.62 |    0.25 | 0.1583 |     - |     - |     664 B |
+| ValueLinq_ValueLambda_SharedPool_Push |     0 |   100 |   896.0 ns |  17.97 ns |  36.31 ns |  4.96 |    0.28 | 0.1011 |     - |     - |     424 B |
+| ValueLinq_ValueLambda_SharedPool_Pull |     0 |   100 |   833.2 ns |  16.48 ns |  25.66 ns |  4.61 |    0.20 | 0.1011 |     - |     - |     424 B |
+|                               ForLoop |     0 |   100 |   180.9 ns |   3.68 ns |   5.73 ns |  1.00 |    0.00 | 0.1013 |     - |     - |     424 B |
+|                                  Linq |     0 |   100 |   480.7 ns |   9.38 ns |  10.80 ns |  2.66 |    0.11 | 0.1221 |     - |     - |     512 B |
+|                            LinqFaster |     0 |   100 |   587.9 ns |  11.70 ns |  25.43 ns |  3.25 |    0.19 | 0.2022 |     - |     - |     848 B |
+|                                LinqAF |     0 |   100 | 6,932.5 ns | 138.62 ns | 246.40 ns | 38.45 |    1.91 |      - |     - |     - |    1576 B |
+|                            StructLinq |     0 |   100 |   777.1 ns |  15.22 ns |  23.70 ns |  4.30 |    0.18 | 0.1068 |     - |     - |     448 B |
+|                  StructLinq_IFunction |     0 |   100 |   599.0 ns |  11.82 ns |  19.42 ns |  3.31 |    0.11 | 0.1011 |     - |     - |     424 B |
+|                             Hyperlinq |     0 |   100 |   473.5 ns |   9.39 ns |  14.62 ns |  2.62 |    0.11 | 0.1011 |     - |     - |     424 B |
+|                        Hyperlinq_Pool |     0 |   100 |   479.2 ns |   9.63 ns |  18.78 ns |  2.65 |    0.12 | 0.0134 |     - |     - |      56 B |

--- a/Results/Range.RangeSelectToList.md
+++ b/Results/Range.RangeSelectToList.md
@@ -12,22 +12,30 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|               Method | Start | Count |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------------- |------ |------ |---------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|              ForLoop |     0 |   100 | 290.5 ns | 3.03 ns | 2.68 ns |  1.00 |    0.00 | 0.5660 |     - |     - |    1184 B |
-|          ForeachLoop |     0 |   100 | 748.5 ns | 5.24 ns | 4.64 ns |  2.58 |    0.03 | 0.5922 |     - |     - |    1240 B |
-|                 Linq |     0 |   100 | 326.8 ns | 2.96 ns | 2.77 ns |  1.12 |    0.02 | 0.2599 |     - |     - |     544 B |
-|           LinqFaster |     0 |   100 | 369.2 ns | 2.35 ns | 2.08 ns |  1.27 |    0.01 | 0.6232 |     - |     - |    1304 B |
-|               LinqAF |     0 |   100 | 798.3 ns | 8.80 ns | 8.23 ns |  2.75 |    0.03 | 0.5655 |     - |     - |    1184 B |
-|           StructLinq |     0 |   100 | 456.8 ns | 2.54 ns | 2.25 ns |  1.57 |    0.01 | 0.2294 |     - |     - |     480 B |
-| StructLinq_IFunction |     0 |   100 | 312.0 ns | 1.93 ns | 1.80 ns |  1.07 |    0.01 | 0.2179 |     - |     - |     456 B |
-|            Hyperlinq |     0 |   100 | 225.6 ns | 1.10 ns | 0.98 ns |  0.78 |    0.01 | 0.2408 |     - |     - |     504 B |
+|                                Method | Start | Count |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------------------- |------ |------ |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
+|                    ValueLinq_Standard |     0 |   100 |   660.9 ns |  13.09 ns |  27.61 ns |   655.5 ns |  0.93 |    0.06 | 0.1087 |     - |     - |     456 B |
+|                       ValueLinq_Stack |     0 |   100 | 1,506.7 ns |  29.16 ns |  32.41 ns | 1,520.3 ns |  2.10 |    0.09 | 0.1659 |     - |     - |     696 B |
+|             ValueLinq_SharedPool_Push |     0 |   100 | 1,049.4 ns |  21.09 ns |  43.55 ns | 1,053.0 ns |  1.47 |    0.07 | 0.1087 |     - |     - |     456 B |
+|             ValueLinq_SharedPool_Pull |     0 |   100 | 1,321.9 ns |  26.31 ns |  48.77 ns | 1,329.6 ns |  1.86 |    0.09 | 0.1087 |     - |     - |     456 B |
+|        ValueLinq_ValueLambda_Standard |     0 |   100 |   474.9 ns |   9.29 ns |  11.41 ns |   479.8 ns |  0.66 |    0.03 | 0.1087 |     - |     - |     456 B |
+|           ValueLinq_ValueLambda_Stack |     0 |   100 | 1,154.7 ns |  22.94 ns |  43.64 ns | 1,165.8 ns |  1.62 |    0.08 | 0.1659 |     - |     - |     696 B |
+| ValueLinq_ValueLambda_SharedPool_Push |     0 |   100 |   921.9 ns |  18.17 ns |  28.28 ns |   932.1 ns |  1.30 |    0.05 | 0.1087 |     - |     - |     456 B |
+| ValueLinq_ValueLambda_SharedPool_Pull |     0 |   100 |   995.1 ns |  19.99 ns |  51.24 ns |   999.7 ns |  1.40 |    0.09 | 0.1087 |     - |     - |     456 B |
+|                               ForLoop |     0 |   100 |   712.4 ns |  14.36 ns |  25.89 ns |   720.4 ns |  1.00 |    0.00 | 0.2823 |     - |     - |    1184 B |
+|                           ForeachLoop |     0 |   100 | 1,491.4 ns |  29.68 ns |  70.53 ns | 1,505.7 ns |  2.10 |    0.13 | 0.2956 |     - |     - |    1240 B |
+|                                  Linq |     0 |   100 |   698.9 ns |  14.08 ns |  37.82 ns |   712.4 ns |  0.98 |    0.06 | 0.1297 |     - |     - |     544 B |
+|                            LinqFaster |     0 |   100 |   795.6 ns |  15.75 ns |  26.74 ns |   802.8 ns |  1.12 |    0.05 | 0.3109 |     - |     - |    1304 B |
+|                                LinqAF |     0 |   100 | 7,734.8 ns | 136.76 ns | 263.50 ns | 7,700.0 ns | 10.88 |    0.61 |      - |     - |     - |    1184 B |
+|                            StructLinq |     0 |   100 |   814.8 ns |  16.20 ns |  25.69 ns |   825.4 ns |  1.14 |    0.06 | 0.1144 |     - |     - |     480 B |
+|                  StructLinq_IFunction |     0 |   100 |   628.7 ns |  12.62 ns |  22.10 ns |   638.0 ns |  0.88 |    0.05 | 0.1087 |     - |     - |     456 B |
+|                             Hyperlinq |     0 |   100 |   566.2 ns |  11.24 ns |  30.39 ns |   573.3 ns |  0.80 |    0.05 | 0.1202 |     - |     - |     504 B |

--- a/Results/Range.RangeToArray.md
+++ b/Results/Range.RangeToArray.md
@@ -12,21 +12,25 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|         Method | Start | Count |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|--------------- |------ |------ |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
-|        ForLoop |     0 |   100 | 132.36 ns | 1.084 ns | 1.014 ns |  1.00 |    0.00 | 0.2027 |     - |     - |     424 B |
-|           Linq |     0 |   100 |  87.02 ns | 0.650 ns | 0.608 ns |  0.66 |    0.01 | 0.2218 |     - |     - |     464 B |
-|     LinqFaster |     0 |   100 |  79.30 ns | 0.751 ns | 0.666 ns |  0.60 |    0.01 | 0.2027 |     - |     - |     424 B |
-|         LinqAF |     0 |   100 | 269.90 ns | 2.125 ns | 1.884 ns |  2.04 |    0.02 | 0.2027 |     - |     - |     424 B |
-|     StructLinq |     0 |   100 | 216.50 ns | 1.442 ns | 1.278 ns |  1.64 |    0.02 | 0.2027 |     - |     - |     424 B |
-|      Hyperlinq |     0 |   100 |  82.95 ns | 0.681 ns | 0.604 ns |  0.63 |    0.01 | 0.2027 |     - |     - |     424 B |
-| Hyperlinq_Pool |     0 |   100 | 120.42 ns | 0.493 ns | 0.437 ns |  0.91 |    0.01 | 0.0267 |     - |     - |      56 B |
+|                    Method | Start | Count |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |------ |------ |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
+|        ValueLinq_Standard |     0 |   100 | 373.7 ns |  7.32 ns |  8.72 ns |  2.16 |    0.08 | 0.1011 |     - |     - |     424 B |
+|           ValueLinq_Stack |     0 |   100 | 635.5 ns | 12.05 ns | 12.89 ns |  3.68 |    0.14 | 0.1583 |     - |     - |     664 B |
+| ValueLinq_SharedPool_Push |     0 |   100 | 751.4 ns | 11.08 ns | 10.36 ns |  4.35 |    0.11 | 0.1011 |     - |     - |     424 B |
+| ValueLinq_SharedPool_Pull |     0 |   100 | 708.8 ns | 13.05 ns | 17.87 ns |  4.11 |    0.18 | 0.1011 |     - |     - |     424 B |
+|                   ForLoop |     0 |   100 | 172.3 ns |  3.52 ns |  5.16 ns |  1.00 |    0.00 | 0.1013 |     - |     - |     424 B |
+|                      Linq |     0 |   100 | 202.4 ns |  4.09 ns |  5.99 ns |  1.18 |    0.05 | 0.1109 |     - |     - |     464 B |
+|                LinqFaster |     0 |   100 | 180.2 ns |  3.56 ns |  4.37 ns |  1.04 |    0.03 | 0.1013 |     - |     - |     424 B |
+|                    LinqAF |     0 |   100 | 470.2 ns |  9.28 ns | 21.50 ns |  2.71 |    0.17 | 0.1011 |     - |     - |     424 B |
+|                StructLinq |     0 |   100 | 443.3 ns |  8.86 ns | 20.53 ns |  2.61 |    0.13 | 0.1011 |     - |     - |     424 B |
+|                 Hyperlinq |     0 |   100 | 197.5 ns |  3.94 ns |  5.52 ns |  1.15 |    0.04 | 0.1013 |     - |     - |     424 B |
+|            Hyperlinq_Pool |     0 |   100 | 238.5 ns |  3.54 ns |  3.31 ns |  1.38 |    0.05 | 0.0134 |     - |     - |      56 B |

--- a/Results/Range.RangeToList.md
+++ b/Results/Range.RangeToList.md
@@ -12,21 +12,25 @@
 ### Results:
 ``` ini
 
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-7567U CPU 3.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
-.NET Core SDK=5.0.100-preview.7.20366.6
-  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
-  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.100
+  [Host]        : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  .NET Core 5.0 : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 
 Job=.NET Core 5.0  Runtime=.NET Core 5.0  
 
 ```
-|      Method | Start | Count |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|------------ |------ |------ |---------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
-|     ForLoop |     0 |   100 | 287.9 ns | 3.07 ns | 2.87 ns |  1.00 |    0.00 | 0.5660 |     - |     - |    1184 B |
-| ForeachLoop |     0 |   100 | 786.4 ns | 3.81 ns | 3.38 ns |  2.73 |    0.03 | 0.5922 |     - |     - |    1240 B |
-|        Linq |     0 |   100 | 213.7 ns | 1.37 ns | 1.28 ns |  0.74 |    0.01 | 0.2370 |     - |     - |     496 B |
-|  LinqFaster |     0 |   100 | 124.8 ns | 1.03 ns | 0.91 ns |  0.43 |    0.01 | 0.4206 |     - |     - |     880 B |
-|      LinqAF |     0 |   100 | 295.8 ns | 3.01 ns | 2.67 ns |  1.03 |    0.01 | 0.2179 |     - |     - |     456 B |
-|  StructLinq |     0 |   100 | 227.1 ns | 1.16 ns | 0.97 ns |  0.79 |    0.01 | 0.2179 |     - |     - |     456 B |
-|   Hyperlinq |     0 |   100 | 131.2 ns | 1.04 ns | 0.97 ns |  0.46 |    0.00 | 0.2332 |     - |     - |     488 B |
+|                    Method | Start | Count |       Mean |    Error |   StdDev |     Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |------ |------ |-----------:|---------:|---------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
+|        ValueLinq_Standard |     0 |   100 |   551.0 ns |  5.03 ns |  4.20 ns |   550.3 ns |  0.87 |    0.02 | 0.1087 |     - |     - |     456 B |
+|           ValueLinq_Stack |     0 |   100 |   900.6 ns |  7.73 ns |  7.23 ns |   902.4 ns |  1.43 |    0.03 | 0.1659 |     - |     - |     696 B |
+| ValueLinq_SharedPool_Push |     0 |   100 |   798.6 ns |  6.26 ns |  5.85 ns |   798.0 ns |  1.26 |    0.02 | 0.1087 |     - |     - |     456 B |
+| ValueLinq_SharedPool_Pull |     0 |   100 |   823.0 ns | 12.05 ns | 11.27 ns |   828.8 ns |  1.30 |    0.02 | 0.1087 |     - |     - |     456 B |
+|                   ForLoop |     0 |   100 |   631.6 ns | 12.61 ns | 11.79 ns |   631.8 ns |  1.00 |    0.00 | 0.2823 |     - |     - |    1184 B |
+|               ForeachLoop |     0 |   100 | 1,388.6 ns | 27.77 ns | 43.23 ns | 1,403.4 ns |  2.18 |    0.09 | 0.2956 |     - |     - |    1240 B |
+|                      Linq |     0 |   100 |   305.4 ns |  6.12 ns |  7.74 ns |   309.8 ns |  0.48 |    0.01 | 0.1183 |     - |     - |     496 B |
+|                LinqFaster |     0 |   100 |   283.3 ns |  5.41 ns |  5.79 ns |   282.5 ns |  0.45 |    0.01 | 0.2103 |     - |     - |     880 B |
+|                    LinqAF |     0 |   100 |   591.6 ns | 11.77 ns | 21.81 ns |   601.2 ns |  0.94 |    0.03 | 0.1087 |     - |     - |     456 B |
+|                StructLinq |     0 |   100 |   521.9 ns |  9.68 ns |  9.51 ns |   525.8 ns |  0.83 |    0.02 | 0.1087 |     - |     - |     456 B |
+|                 Hyperlinq |     0 |   100 |   226.7 ns |  4.49 ns |  6.58 ns |   225.6 ns |  0.36 |    0.01 | 0.1166 |     - |     - |     488 B |


### PR DESCRIPTION
I have put these into a partial class, as easier to control given that this is meant as as "replacement" for System.Linq (i.e. you would drag one or the other namespace via a using, rather than both).

Also, as Cistern.ValueLinq is fully composable I have given a number of different methods for how to do each problem, which ends up as a bit of a combinatorial explosion, but also another reason why doing it in the partial class makes sense.

The "standard" version (i.e. `ToList()`/`ToArray()` with no arguments) are supposed to mirror System.Linq as much as possible, i.e. they won't using pooling, but you can specify some arguments which nudges them in various directions (but the logic is a bit convoluted, as they try to be "smart"). There are `To(Array|List)(ViaPool|ViaStack)` to force a particular style.

Another axis of freedom is standard delegates (`Func<,>`) or value based `IFunc<,>`. Both of these have value-type and reference-type arguments.

And yet another axis of freedom, where List is the source, is if you want to access it via Index or via it's `List<>.Enumerator`. By default it once again follows System.Linq in that it uses the Enumerator, but you can force it by using `OfListByIndex`. Once again there are some "smarts" in place here, because although System.Linq does it by Enumerator, it also has some optimizations on ToArray/ToList which doesn't. Which makes it a bit hard to fully replicate it's functionality, but if the source is originally an `IEnumerable<>` rather than a `List` then if it's iterator in `foreach` it uses the `Enumerator` but if it passes through to an Aggregation function then it uses the index version (basically).

Which is the final degree of freedom which is offered in the array pool version where you can act either in pull mode (ie, through similar mechanism to IEnumerator) or a push mode (where the actions are inverted).

Anyway, it means that you have lots of choices to choose from, but I have tried to make the simplist (i.e. the one where your code looks exactly the same as System.Linqs) a reasonable default choice.

In the broader context, I think I'm fairly happy with overall architecture now of Cistern.ValueLinq, so now I just have to fill in all the details! Next step is to pull over the SIMD Vector stuff that I'd done in Cistern.Linq :-) And hopefully get around to filling in the rest of the System.Linq API sooner rather than later. But think I'm pretty close to burnout after this initial sprint to this junction!
