### PR TITLE
Removed Cistern.Linq's Where/Select that used a struct based in function

### DIFF
--- a/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToArray.CisternValueLinq.cs
@@ -94,38 +94,6 @@ namespace LinqBenchmarks.Array.ValueType
             .Where(new IsEven())
             .Select(new MultipleByTwo(), default(FatValueType))
             .ToArrayUsePool(viaPull: true);
-
-        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
-        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_Standard() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArray();
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_Stack() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUseStack();
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUsePool(viaPull: false);
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUsePool(viaPull: true);
-
     }
 }
 

--- a/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/Array/ValueType/ArrayValueTypeWhereSelectToList.CisternValueLinq.cs
@@ -94,38 +94,6 @@ namespace LinqBenchmarks.Array.ValueType
             .Where(new IsEven())
             .Select(new MultipleByTwo(), default(FatValueType))
             .ToListUsePool(viaPull: true);
-
-        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
-        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_Standard() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToList();
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_Stack() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUseStack();
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUsePool(viaPull: false);
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUsePool(viaPull: true);
-
     }
 }
 

--- a/LinqBenchmarks/LinqBenchmarks.csproj
+++ b/LinqBenchmarks/LinqBenchmarks.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Cistern.ValueLinq">
-      <Version>0.0.11</Version>
+      <Version>0.1.14</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToArray.CisternValueLinq.cs
+++ b/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToArray.CisternValueLinq.cs
@@ -94,42 +94,6 @@ namespace LinqBenchmarks.List.ValueType
             .Select(new MultipleByTwo(), default(FatValueType))
             .ToArrayUsePool(viaPull: true);
 
-        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
-        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_Standard() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArray();
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_Stack() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUseStack();
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUsePool(viaPull: false);
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUsePool(viaPull: true);
-
-
-
-
-
-
         [Benchmark]
         public FatValueType[] ValueLinq_Standard_ByIndex() =>
             source
@@ -223,38 +187,6 @@ namespace LinqBenchmarks.List.ValueType
             .OfListByIndex()
             .Where(new IsEven())
             .Select(new MultipleByTwo(), default(FatValueType))
-            .ToArrayUsePool(viaPull: true);
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_Standard_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArray();
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_Stack_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUseStack();
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Push_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToArrayUsePool(viaPull: false);
-
-        [Benchmark]
-        public FatValueType[] ValueLinq_ValueLambda_Ref_SharedPool_Pull_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
             .ToArrayUsePool(viaPull: true);
     }
 }

--- a/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToList.CisternValueLinq.cs
+++ b/LinqBenchmarks/List/ValueType/ListValueTypeWhereSelectToList.CisternValueLinq.cs
@@ -95,41 +95,6 @@ namespace LinqBenchmarks.List.ValueType
             .Select(new MultipleByTwo(), default(FatValueType))
             .ToListUsePool(viaPull: true);
 
-        struct InIsEven : IInFunc<FatValueType, bool> { public bool Invoke(in FatValueType t) => t.IsEven(); }
-        struct InMultipleByTwo : IInFunc<FatValueType, FatValueType> { public FatValueType Invoke(in FatValueType t) => t * 2; }
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_Standard() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToList();
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_Stack() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUseStack();
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Push() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUsePool(viaPull: false);
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Pull() =>
-            source
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUsePool(viaPull: true);
-
-
-
-
-
 
         [Benchmark]
         public List<FatValueType> ValueLinq_Standard_ByIndex() =>
@@ -224,38 +189,6 @@ namespace LinqBenchmarks.List.ValueType
             .OfListByIndex()
             .Where(new IsEven())
             .Select(new MultipleByTwo(), default(FatValueType))
-            .ToListUsePool(viaPull: true);
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_Standard_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToList();
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_Stack_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUseStack();
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Push_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
-            .ToListUsePool(viaPull: false);
-
-        [Benchmark]
-        public List<FatValueType> ValueLinq_ValueLambda_Ref_SharedPool_Pull_ByIndex() =>
-            source
-            .OfListByIndex()
-            .Where(new InIsEven())
-            .Select(new InMultipleByTwo(), default(FatValueType))
             .ToListUsePool(viaPull: true);
     }
 }


### PR DESCRIPTION
Updated to latest Cistern.ValueLinq, where the `IInFunc<>` version for Where/Select had been removed (possibly temporarily, was juggling too many things)