### PR TITLE
Update StructLinq to 0.26.0

### DIFF
--- a/LinqBenchmarks/LinqBenchmarks.csproj
+++ b/LinqBenchmarks/LinqBenchmarks.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Streams.CSharp" Version="0.6.0" />
-    <PackageReference Include="StructLinq.BCL" Version="0.25.3" />
+    <PackageReference Include="StructLinq" Version="0.26.0" />
     <PackageReference Include="System.Interactive" Version="5.0.0" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>

--- a/LinqBenchmarks/Program.cs
+++ b/LinqBenchmarks/Program.cs
@@ -102,8 +102,8 @@ namespace LinqBenchmarks
             var streamsVersion = GetInformationalVersion(typeof(Nessos.Streams.CSharp.Streams).Assembly);
             logger.WriteLine($"- Streams.CSharp: [{streamsVersion}](https://www.nuget.org/packages/Streams.CSharp/{streamsVersion})");
 
-            var structLinqVersion = GetInformationalVersion(typeof(StructLinq.BCL.List.ListEnumerable<>).Assembly);
-            logger.WriteLine($"- StructLinq.BCL: [{structLinqVersion}](https://www.nuget.org/packages/StructLinq.BCL/{structLinqVersion})");
+            var structLinqVersion = GetInformationalVersion(typeof(StructLinq.List.ListEnumerable<>).Assembly);
+            logger.WriteLine($"- StructLinq.BCL: [{structLinqVersion}](https://www.nuget.org/packages/StructLinq/{structLinqVersion})");
 
             var hyperlinqVersion = GetInformationalVersion(typeof(ValueEnumerable).Assembly);
             logger.WriteLine($"- NetFabric.Hyperlinq: [{hyperlinqVersion}](https://www.nuget.org/packages/NetFabric.Hyperlinq/{hyperlinqVersion})");


### PR DESCRIPTION
Hi,
I have juste merged StructLinq.BCL.dll into StructLinq.dll

It is more simple to have "just" one dll.

Regards,